### PR TITLE
Add 4th iteration metric api docs for newest chart ui

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -74,6 +74,21 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/GetDataCentersResponse"
+              examples:
+                example:
+                  summary: Data centers
+                  value:
+                    code: 200
+                    data:
+                    - name: example-data-center
+                      version: Cube Appliance 3.0.0
+                      virtualIp: 10.10.10.10
+                      isLocal: true
+                      isHaEnabled: false
+                      additional:
+                        helpUrl: https://www.bigstack.co/contact-us
+                    msg: fetch data center list successfully
+                    status: ok
         '500':
           description: Internal Server Error
           content:
@@ -109,7 +124,10 @@ paths:
         required: true
         schema:
           type: string
-          enum: [system, host, instance]
+          enum:
+          - system
+          - host
+          - instance
         description: The type of event to query, the value can be only 'system', 'host',
           and 'instance'.
         example: system
@@ -209,7 +227,10 @@ paths:
         required: true
         schema:
           type: string
-          enum: ['start', 'host', 'instance']
+          enum:
+          - start
+          - host
+          - instance
         description: The type of event to query, the value can be only 'system', 'host',
           and 'instance'.
         example: system
@@ -998,6 +1019,96 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/GetMetricsResponse"
+              examples:
+                example1:
+                  summary: Overview of data center metrics
+                  value:
+                    code: 200
+                    data:
+                      dataCenter:
+                        usage:
+                          cpu:
+                            totalCores: 96
+                            usedCores: 8.7942
+                            usedPercent: 9.17
+                            freeCores: 87.2057
+                            freePercent: 90.83
+                          memory:
+                            totalMiB: 515645.789
+                            usedMiB: 291691.289
+                            usedPercent: 56.5681
+                            freeMiB: 223954.5
+                            freePercent: 43.4318
+                      host:
+                        role:
+                          controlConverged: 2
+                          control: 0
+                          compute: 0
+                          storage: 0
+                          others: 0
+                        usages:
+                        - role: control-converged
+                          name: example-node-0
+                          address: 10.10.10.10
+                          usage:
+                            cpu:
+                              totalCores: 48
+                              usedCores: 4.3971
+                              usedPercent: 4.335
+                              freeCores: 43.6028
+                              freePercent: 95.6649
+                            memory:
+                              totalMiB: 257822.8945
+                              usedMiB: 145845.6445
+                              usedPercent: 56.5681
+                              freeMiB: 111977.25
+                              freePercent: 43.4318
+                        - role: control-converged
+                          name: example-node-1
+                          address: 10.10.10.11
+                          usage:
+                            cpu:
+                              totalCores: 48
+                              usedCores: 4.3971
+                              usedPercent: 4.335
+                              freeCores: 43.6028
+                              freePercent: 95.6649
+                            memory:
+                              totalMiB: 257822.8945
+                              usedMiB: 145845.6445
+                              usedPercent: 56.5681
+                              freeMiB: 111977.25
+                              freePercent: 43.4318
+                      vm:
+                        status:
+                          total: 16
+                          running: 14
+                          stopped: 2
+                          suspend: 0
+                          paused: 0
+                          error: 0
+                          unknown: 0
+                        usage:
+                          vcpu:
+                            totalCores: 48
+                            usedCores: 38
+                            usedPercent: 0.7916
+                            freeCores: 10
+                            freePercent: 0.2083
+                          memory:
+                            totalMiB: 257822
+                            usedMiB: 96424
+                            usedPercent: 0.3739
+                            freeMiB: 161398
+                            freePercent: 0.626
+                          storage:
+                            totalMiB: 12571648
+                            usedMiB: 716800
+                            usedPercent: 0.057
+                            freeMiB: 11854848
+                            freePercent: 0.9429
+                    msg: fetch metrics successfully
+                    status: ok
         '500':
           description: Internal Server Error
           content:
@@ -1033,7 +1144,17 @@ paths:
         required: true
         schema:
           type: string
-          enum: [cpuUsage, memoryUsage, diskUsage, diskBandwidth, diskIops, diskLatency, diskReadIops, diskWriteIops, networkTrafficIn, networkTrafficOut]
+          enum:
+          - cpuUsage
+          - memoryUsage
+          - diskUsage
+          - diskBandwidth
+          - diskIops
+          - diskLatency
+          - diskReadIops
+          - diskWriteIops
+          - networkTrafficIn
+          - networkTrafficOut
         description: The type of metric to query, the value can be 'cpuUsage', 'memoryUsage',
           'diskUsage', 'diskBandwidth', 'diskIops', 'diskLatency', 'diskReadIops',
           'diskWriteIops', 'networkTrafficIn', or 'networkTrafficOut'.
@@ -1043,7 +1164,10 @@ paths:
         required: true
         schema:
           type: string
-          enum: [summary, history, rank]
+          enum:
+          - summary
+          - history
+          - rank
         description: The type of view to query, the value can be only 'summary', 'history',
           or 'rank'.
         example: 1
@@ -1052,7 +1176,9 @@ paths:
         required: true
         schema:
           type: string
-          enum: [hosts, vms]
+          enum:
+          - hosts
+          - vms
         description: The type of entity to query, the value can be 'hosts' or 'vms'
         example: hosts
       - in: query
@@ -1196,11 +1322,11 @@ paths:
                   value:
                     code: 200
                     data:
-                      totalCores: 0
-                      usedCores: 0
-                      usedPercent: 9.6774
-                      freeCores: 0
-                      freePercent: 90.3225
+                      totalCores: 48
+                      usedCores: 4.7778
+                      usedPercent: 6.6988
+                      freeCores: 43.2221
+                      freePercent: 93.3011
                     msg: fetch metrics successfully
                     status: ok
                 example2:
@@ -1210,12 +1336,28 @@ paths:
                     data:
                     - id: example-node-0
                       name: example-node-0
-                      usedPercent: 9.8248
-                      freePercent: 90.1752
+                      freePercent: 12.1752
+                      history:
+                      - time: '2025-02-14T00:19:00Z'
+                        usedPercent: 10.3202
+                      - time: '2025-02-14T00:20:00Z'
+                        usedPercent: 10.1465
+                      - time: '2025-02-14T00:21:00Z'
+                        usedPercent: 14.5854
+                      - time: '2025-02-14T00:22:00Z'
+                        usedPercent: 11.9773
                     - id: example-node-1
                       name: example-node-1
                       usedPercent: 8.8248
-                      freePercent: 91.1752
+                      history:
+                      - time: '2025-02-14T00:19:00Z'
+                        usedPercent: 9.3202
+                      - time: '2025-02-14T00:20:00Z'
+                        usedPercent: 9.1465
+                      - time: '2025-02-14T00:21:00Z'
+                        usedPercent: 7.5854
+                      - time: '2025-02-14T00:22:00Z'
+                        usedPercent: 6.9773
                     msg: fetch metrics successfully
                     status: ok
                 example3:
@@ -1237,12 +1379,28 @@ paths:
                     data:
                     - id: example-node-0
                       name: example-node-0
-                      usedPercent: 38.1752
-                      freePercent: 61.8248
+                      usedPercent: 56.4807
+                      history:
+                      - time: '2025-02-14T00:23:00Z'
+                        usedPercent: 56.4997
+                      - time: '2025-02-14T00:24:00Z'
+                        usedPercent: 56.4998
+                      - time: '2025-02-14T00:25:00Z'
+                        usedPercent: 56.4963
+                      - time: '2025-02-14T00:26:00Z'
+                        usedPercent: 56.4758
                     - id: example-node-1
                       name: example-node-1
                       usedPercent: 37.1752
-                      freePercent: 62.8248
+                      history:
+                      - time: '2025-02-14T00:23:00Z'
+                        usedPercent: 36.4997
+                      - time: '2025-02-14T00:24:00Z'
+                        usedPercent: 36.4998
+                      - time: '2025-02-14T00:25:00Z'
+                        usedPercent: 36.4963
+                      - time: '2025-02-14T00:26:00Z'
+                        usedPercent: 36.4758
                     msg: fetch metrics successfully
                     status: ok
                 example5:
@@ -1252,12 +1410,28 @@ paths:
                     data:
                     - id: example-node-0
                       name: example-node-0
-                      usedPercent: 38.1752
-                      freePercent: 61.8248
+                      usedPercent: 25.3645
+                      history:
+                      - time: '2025-02-14T00:26:00Z'
+                        usedPercent: 25.7166
+                      - time: '2025-02-14T00:27:00Z'
+                        usedPercent: 25.7188
+                      - time: '2025-02-14T00:28:00Z'
+                        usedPercent: 25.7209
+                      - time: '2025-02-14T00:29:00Z'
+                        usedPercent: 25.7243
                     - id: example-node-1
                       name: example-node-1
-                      usedPercent: 37.1752
-                      freePercent: 62.8248
+                      usedPercent: 15.3645
+                      history:
+                      - time: '2025-02-14T00:26:00Z'
+                        usedPercent: 15.7166
+                      - time: '2025-02-14T00:27:00Z'
+                        usedPercent: 15.7188
+                      - time: '2025-02-14T00:28:00Z'
+                        usedPercent: 15.7209
+                      - time: '2025-02-14T00:29:00Z'
+                        usedPercent: 15.7243
                     msg: fetch metrics successfully
                     status: ok
                 example6:
@@ -1325,26 +1499,26 @@ paths:
                     data:
                       read:
                       - time: '2025-02-08T22:58:00Z'
-                        ms: 4999.5
+                        millisecond: 4999.5
                       - time: '2025-02-08T22:59:00Z'
-                        ms: 21365.5666
+                        millisecond: 21365.5666
                       - time: '2025-02-08T23:00:00Z'
-                        ms: 39951.6333
+                        millisecond: 39951.6333
                       - time: '2025-02-08T23:01:00Z'
-                        ms: 6255.1333
+                        millisecond: 6255.1333
                       - time: '2025-02-08T23:02:00Z'
-                        ms: 5838730.85
+                        millisecond: 5838730.85
                       write:
                       - time: '2025-02-08T22:58:00Z'
-                        ms: 12624417.95
+                        millisecond: 12624417.95
                       - time: '2025-02-08T22:59:00Z'
-                        ms: 29347351.6333
+                        millisecond: 29347351.6333
                       - time: '2025-02-08T23:00:00Z'
-                        ms: 5219905.3
+                        millisecond: 5219905.3
                       - time: '2025-02-08T23:01:00Z'
-                        ms: 9249751.6666
+                        millisecond: 9249751.6666
                       - time: '2025-02-08T23:02:00Z'
-                        ms: 10661656.35
+                        millisecond: 10661656.35
                     msg: fetch metrics successfully
                     status: ok
                 example9:
@@ -1354,10 +1528,28 @@ paths:
                     data:
                     - id: example-node-0
                       name: example-node-0
-                      packets: 20739.3592
+                      packets: 7466.5592
+                      history:
+                      - time: '2025-02-14T00:32:00Z'
+                        packets: 50064.9333
+                      - time: '2025-02-14T00:33:00Z'
+                        packets: 7141170.1333
+                      - time: '2025-02-14T00:34:00Z'
+                        packets: 39644.1333
+                      - time: '2025-02-14T00:35:00Z'
+                        packets: 45140
                     - id: example-node-1
                       name: example-node-1
-                      packets: 1739.3592
+                      packets: 1126.5592
+                      history:
+                      - time: '2025-02-14T00:32:00Z'
+                        packets: 1467.9333
+                      - time: '2025-02-14T00:33:00Z'
+                        packets: 1321.1333
+                      - time: '2025-02-14T00:34:00Z'
+                        packets: 1211.1333
+                      - time: '2025-02-14T00:35:00Z'
+                        packets: 1131.5145
                     msg: fetch metrics successfully
                     status: ok
                 example10:
@@ -1367,10 +1559,28 @@ paths:
                     data:
                     - id: example-node-0
                       name: example-node-0
-                      packets: 20739.3592
+                      packets: 3595.9166
+                      history:
+                      - time: '2025-02-14T00:35:00Z'
+                        packets: 13138
+                      - time: '2025-02-14T00:36:00Z'
+                        packets: 41106.6666
+                      - time: '2025-02-14T00:37:00Z'
+                        packets: 149872.1333
+                      - time: '2025-02-14T00:38:00Z'
+                        packets: 12152.6666
                     - id: example-node-1
                       name: example-node-1
-                      packets: 1739.3592
+                      packets: 1595.9166
+                      history:
+                      - time: '2025-02-14T00:35:00Z'
+                        packets: 3138
+                      - time: '2025-02-14T00:36:00Z'
+                        packets: 11106.6666
+                      - time: '2025-02-14T00:37:00Z'
+                        packets: 149872.1333
+                      - time: '2025-02-14T00:38:00Z'
+                        packets: 12152.6666
                     msg: fetch metrics successfully
                     status: ok
                 example11:
@@ -1380,12 +1590,28 @@ paths:
                     data:
                     - id: example-vm-0
                       name: example-vm-0
-                      usedPercent: 9.8248
-                      freePercent: 90.1752
+                      usedPercent: 22
+                      history:
+                      - time: '2025-02-14T00:34:52Z'
+                        usedPercent: 21
+                      - time: '2025-02-14T00:35:22Z'
+                        usedPercent: 23
+                      - time: '2025-02-14T00:35:52Z'
+                        usedPercent: 20
+                      - time: '2025-02-14T00:36:22Z'
+                        usedPercent: 22
                     - id: example-vm-1
                       name: example-vm-1
-                      usedPercent: 8.8248
-                      freePercent: 91.1752
+                      usedPercent: 16
+                      history:
+                      - time: '2025-02-14T00:34:52Z'
+                        usedPercent: 20
+                      - time: '2025-02-14T00:35:22Z'
+                        usedPercent: 18
+                      - time: '2025-02-14T00:35:52Z'
+                        usedPercent: 20
+                      - time: '2025-02-14T00:36:23Z'
+                        usedPercent: 18
                     msg: fetch metrics successfully
                     status: ok
                 example12:
@@ -1407,12 +1633,28 @@ paths:
                     data:
                     - id: example-vm-0
                       name: example-vm-0
-                      usedPercent: 38.1752
-                      freePercent: 61.8248
+                      usedPercent: 60.6915
+                      history:
+                      - time: '2025-02-14T00:35:52Z'
+                        usedPercent: 61.6362
+                      - time: '2025-02-14T00:36:23Z'
+                        usedPercent: 61.4931
+                      - time: '2025-02-14T00:36:53Z'
+                        usedPercent: 60.9485
+                      - time: '2025-02-14T00:37:23Z'
+                        usedPercent: 60.3947
                     - id: example-vm-1
                       name: example-vm-1
-                      usedPercent: 37.1752
-                      freePercent: 62.8248
+                      usedPercent: 36.6008
+                      history:
+                      - time: '2025-02-14T00:35:53Z'
+                        usedPercent: 36.6073
+                      - time: '2025-02-14T00:36:23Z'
+                        usedPercent: 36.6105
+                      - time: '2025-02-14T00:36:53Z'
+                        usedPercent: 36.6105
+                      - time: '2025-02-14T00:37:23Z'
+                        usedPercent: 36.6101
                     msg: fetch metrics successfully
                     status: ok
                 example14:
@@ -1423,15 +1665,25 @@ paths:
                     - id: 9d56d601-85f0-4bfe-992d-ba72ab174552
                       name: example-vm-0
                       device: sda
-                      usage: 300.45
-                      usedPercent: 0
-                      freePercent: 0
+                      ops: 1640.3
+                      history:
+                      - time: '2025-02-14T00:38:53+08:00'
+                        ops: 1345.3
+                      - time: '2025-02-14T00:39:23+08:00'
+                        ops: 1123.3
+                      - time: '2025-02-14T00:39:53+08:00'
+                        ops: 1345.3
                     - id: 301c55e3-5133-4c2c-9dda-4c31c382918d
                       name: example-vm-1
                       device: sdc
-                      usage: 245.43
-                      usedPercent: 0
-                      freePercent: 0
+                      ops: 235.35
+                      history:
+                      - time: '2025-02-14T00:38:53+08:00'
+                        ops: 124.3
+                      - time: '2025-02-14T00:39:23+08:00'
+                        ops: 214.3
+                      - time: '2025-02-14T00:39:53+08:00'
+                        ops: 324.3
                     msg: fetch metrics successfully
                     status: ok
                 example15:
@@ -1442,15 +1694,25 @@ paths:
                     - id: 9d56d601-85f0-4bfe-992d-ba72ab174552
                       name: example-vm-0
                       device: sda
-                      usage: 157060.8919
-                      usedPercent: 0
-                      freePercent: 0
+                      ops: 184158.3022
+                      history:
+                      - time: '2025-02-14T00:43:53+08:00'
+                        ops: 182514.0885
+                      - time: '2025-02-14T00:44:23+08:00'
+                        ops: 165440.9962
+                      - time: '2025-02-14T00:44:53+08:00'
+                        ops: 784010.6095
                     - id: 301c55e3-5133-4c2c-9dda-4c31c382918d
                       name: example-vm-1
                       device: sdc
-                      usage: 65907.0124
-                      usedPercent: 0
-                      freePercent: 0
+                      ops: 39589.3872
+                      history:
+                      - time: '2025-02-14T00:43:53+08:00'
+                        ops: 46107.319
+                      - time: '2025-02-14T00:44:23+08:00'
+                        ops: 45280.7243
+                      - time: '2025-02-14T00:44:53+08:00'
+                        ops: 42949.9957
                     msg: fetch metrics successfully
                     status: ok
                 example16:
@@ -1460,14 +1722,30 @@ paths:
                     data:
                     - id: 9d56d601-85f0-4bfe-992d-ba72ab174552
                       name: example-vm-0
-                      usage: 20739.3592
-                      usedPercent: 0
-                      freePercent: 0
+                      device: tap8c5cff7e-b9
+                      packets: 49756.9502
+                      history:
+                      - time: '2025-02-14T00:45:53Z'
+                        packets: 370067.1842
+                      - time: '2025-02-14T00:46:23Z'
+                        packets: 409181.4363
+                      - time: '2025-02-14T00:46:53Z'
+                        packets: 711269.641
+                      - time: '2025-02-14T00:47:23Z'
+                        packets: 398196.6271
                     - id: 301c55e3-5133-4c2c-9dda-4c31c382918d
                       name: example-vm-1
-                      usage: 1739.3592
-                      usedPercent: 0
-                      freePercent: 0
+                      device: tapdf5be3d9-c6
+                      packets: 25784.0787
+                      history:
+                      - time: '2025-02-14T00:45:53Z'
+                        packets: 184756.5743
+                      - time: '2025-02-14T00:46:23Z'
+                        packets: 207790.9312
+                      - time: '2025-02-14T00:46:53Z'
+                        packets: 270692.8834
+                      - time: '2025-02-14T00:47:23Z'
+                        packets: 200824.0072
                     msg: fetch metrics successfully
                     status: ok
                 example17:
@@ -1477,14 +1755,30 @@ paths:
                     data:
                     - id: 9d56d601-85f0-4bfe-992d-ba72ab174552
                       name: example-vm-0
-                      usage: 20739.3592
-                      usedPercent: 0
-                      freePercent: 0
+                      device: tap8c5cff7e-b9
+                      packets: 54213.0697
+                      history:
+                      - time: '2025-02-14T00:46:53Z'
+                        packets: 1027891.3544
+                      - time: '2025-02-14T00:47:23Z'
+                        packets: 462342.2831
+                      - time: '2025-02-14T00:47:53Z'
+                        packets: 435980.7214
+                      - time: '2025-02-14T00:48:23Z'
+                        packets: 447617.6397
                     - id: 301c55e3-5133-4c2c-9dda-4c31c382918d
                       name: example-vm-1
-                      usage: 1739.3592
-                      usedPercent: 0
-                      freePercent: 0
+                      device: tapdf5be3d9-c6
+                      packets: 13561.1536
+                      history:
+                      - time: '2025-02-14T00:46:53Z'
+                        packets: 128726.0911
+                      - time: '2025-02-14T00:47:23Z'
+                        packets: 109373.8789
+                      - time: '2025-02-14T00:47:53Z'
+                        packets: 109977.441
+                      - time: '2025-02-14T00:48:23Z'
+                        packets: 111826.9696
                     msg: fetch metrics successfully
                     status: ok
         '400':
@@ -1760,22 +2054,23 @@ components:
             - virtualIp
             - isHaEnabled
             - isLocal
+            - additional
             properties:
               name:
                 type: string
-                example: bigstack-data-center
               version:
                 type: string
-                example: Cube Appliance 3.0.0
               virtualIp:
                 type: string
-                example: 10.10.10.10
               isHaEnabled:
                 type: boolean
-                example: false
               isLocal:
                 type: boolean
-                example: true
+              additional:
+                type: object
+                properties:
+                  helpUrl:
+                    type: string
         msg:
           type: string
           example: fetch data center list successfully
@@ -1886,8 +2181,8 @@ components:
         data:
           type: object
           required:
-            - events
-            - limit
+          - events
+          - limit
           properties:
             events:
               type: array
@@ -2306,7 +2601,7 @@ components:
           example: 200
         data:
           type: object
-          example: null
+          example: 
         msg:
           type: string
           example: update licenses successfully
@@ -2327,48 +2622,22 @@ components:
         data:
           type: object
           required:
+          - dataCenter
           - host
           - vm
           properties:
-            host:
+            dataCenter:
               type: object
               required:
-              - role
-              - status
               - usage
               properties:
-                role:
-                  type: object
-                  required:
-                  - controlConverged
-                  - control
-                  - compute
-                  - storage
-                  - others
-                  properties:
-                    controlConverged:
-                      type: integer
-                      example: 10
-                    control:
-                      type: integer
-                      example: 3
-                    compute:
-                      type: integer
-                      example: 5
-                    storage:
-                      type: integer
-                      example: 2
-                    others:
-                      type: integer
-                      example: 0
                 usage:
                   type: object
                   required:
-                  - vcpu
+                  - cpu
                   - memory
-                  - storage
                   properties:
-                    vcpu:
+                    cpu:
                       type: object
                       required:
                       - totalCores
@@ -2416,30 +2685,96 @@ components:
                         freePercent:
                           type: number
                           example: 61.8
+            host:
+              type: object
+              required:
+              - role
+              - usages
+              properties:
+                role:
+                  type: object
+                  required:
+                  - controlConverged
+                  - control
+                  - compute
+                  - storage
+                  - others
+                  properties:
+                    controlConverged:
+                      type: integer
+                      example: 10
+                    control:
+                      type: integer
+                      example: 3
+                    compute:
+                      type: integer
+                      example: 5
                     storage:
-                      type: object
-                      required:
-                      - totalMiB
-                      - usedMiB
-                      - usedPercent
-                      - freeMiB
-                      - freePercent
-                      properties:
-                        totalMiB:
-                          type: integer
-                          example: 102400
-                        usedMiB:
-                          type: integer
-                          example: 51200
-                        usedPercent:
-                          type: number
-                          example: 50.12
-                        freeMiB:
-                          type: integer
-                          example: 51200
-                        freePercent:
-                          type: number
-                          example: 50.12
+                      type: integer
+                      example: 2
+                    others:
+                      type: integer
+                      example: 0
+                usages:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - role
+                    - name
+                    - address
+                    - usage
+                    properties:
+                      role:
+                        type: string
+                      name:
+                        type: string
+                      address:
+                        type: string
+                      usage:
+                        type: object
+                        required:
+                        - cpu
+                        - memory
+                        properties:
+                          cpu:
+                            type: object
+                            required:
+                            - totalCores
+                            - usedCores
+                            - usedPercent
+                            - freeCores
+                            - freePercent
+                            properties:
+                              totalCores:
+                                type: integer
+                              usedCores:
+                                type: integer
+                              usedPercent:
+                                type: number
+                              freeCores:
+                                type: integer
+                              freePercent:
+                                type: number
+                          memory:
+                            type: object
+                            required:
+                            - totalMiB
+                            - usedMiB
+                            - usedPercent
+                            - freeMiB
+                            - freePercent
+                            properties:
+                              totalMiB:
+                                type: integer
+                              usedMiB:
+                                type: integer
+                              usedPercent:
+                                type: number
+                              freeMiB:
+                                type: integer
+                              freePercent:
+                                type: number
             vm:
               type: object
               required:
@@ -2616,7 +2951,7 @@ components:
             - id
             - name
             - usedPercent
-            - freePercent
+            - history
             properties:
               id:
                 type: string
@@ -2624,8 +2959,19 @@ components:
                 type: string
               usedPercent:
                 type: number
-              freePercent:
-                type: number
+              history:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - time
+                  - usedPercent
+                  properties:
+                    time:
+                      type: string
+                      format: date-time
+                    usedPercent:
+                      type: number
         msg:
           type: string
           example: fetch metrics successfully
@@ -2685,7 +3031,7 @@ components:
             - id
             - name
             - usedPercent
-            - freePercent
+            - history
             properties:
               id:
                 type: string
@@ -2693,8 +3039,19 @@ components:
                 type: string
               usedPercent:
                 type: number
-              freePercent:
-                type: number
+              history:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - time
+                  - usedPercent
+                  properties:
+                    time:
+                      type: string
+                      format: date-time
+                    usedPercent:
+                      type: number
         msg:
           type: string
           example: fetch metrics successfully
@@ -2719,7 +3076,7 @@ components:
             - id
             - name
             - usedPercent
-            - freePercent
+            - history
             properties:
               id:
                 type: string
@@ -2727,8 +3084,19 @@ components:
                 type: string
               usedPercent:
                 type: number
-              freePercent:
-                type: number
+              history:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - time
+                  - usedPercent
+                  properties:
+                    time:
+                      type: string
+                      format: date-time
+                    usedPercent:
+                      type: number
         msg:
           type: string
           example: fetch metrics successfully
@@ -2849,12 +3217,12 @@ components:
                 type: object
                 required:
                 - time
-                - ms
+                - millisecond
                 properties:
                   time:
                     type: string
                     format: date-time
-                  ms:
+                  millisecond:
                     type: number
             write:
               type: array
@@ -2862,12 +3230,12 @@ components:
                 type: object
                 required:
                 - time
-                - ms
+                - millisecond
                 properties:
                   time:
                     type: string
                     format: date-time
-                  ms:
+                  millisecond:
                     type: number
         msg:
           type: string
@@ -2891,6 +3259,7 @@ components:
             - id
             - name
             - packets
+            - history
             properties:
               id:
                 type: string
@@ -2898,6 +3267,19 @@ components:
                 type: string
               packets:
                 type: number
+              history:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - time
+                  - packets
+                  properties:
+                    time:
+                      type: string
+                      format: date-time
+                    packets:
+                      type: number
         msg:
           type: string
           example: fetch metrics successfully
@@ -2922,6 +3304,7 @@ components:
             - id
             - name
             - packets
+            - history
             properties:
               id:
                 type: string
@@ -2929,6 +3312,19 @@ components:
                 type: string
               packets:
                 type: number
+              history:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - time
+                  - packets
+                  properties:
+                    time:
+                      type: string
+                      format: date-time
+                    packets:
+                      type: number
         msg:
           type: string
           example: fetch metrics successfully
@@ -2953,7 +3349,7 @@ components:
             - id
             - name
             - usedPercent
-            - freePercent
+            - history
             properties:
               id:
                 type: string
@@ -2961,8 +3357,19 @@ components:
                 type: string
               usedPercent:
                 type: number
-              freePercent:
-                type: number
+              history:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - time
+                  - usedPercent
+                  properties:
+                    time:
+                      type: string
+                      format: date-time
+                    usedPercent:
+                      type: number
         msg:
           type: string
           example: fetch metrics successfully
@@ -3022,7 +3429,7 @@ components:
             - id
             - name
             - usedPercent
-            - freePercent
+            - history
             properties:
               id:
                 type: string
@@ -3030,8 +3437,19 @@ components:
                 type: string
               usedPercent:
                 type: number
-              freePercent:
-                type: number
+              history:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - time
+                  - usedPercent
+                  properties:
+                    time:
+                      type: string
+                      format: date-time
+                    usedPercent:
+                      type: number
         msg:
           type: string
           example: fetch metrics successfully
@@ -3056,9 +3474,8 @@ components:
             - id
             - name
             - device
-            - usage
-            - usedPercent
-            - freePercent
+            - ops
+            - history
             properties:
               id:
                 type: string
@@ -3066,12 +3483,21 @@ components:
                 type: string
               device:
                 type: string
-              usage:
+              ops:
                 type: number
-              usedPercent:
-                type: number
-              freePercent:
-                type: number
+              history:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - time
+                  - ops
+                  properties:
+                    time:
+                      type: string
+                      format: date-time
+                    ops:
+                      type: number
         msg:
           type: string
           example: fetch metrics successfully
@@ -3096,9 +3522,8 @@ components:
             - id
             - name
             - device
-            - usage
-            - usedPercent
-            - freePercent
+            - ops
+            - history
             properties:
               id:
                 type: string
@@ -3106,12 +3531,21 @@ components:
                 type: string
               device:
                 type: string
-              usage:
+              ops:
                 type: number
-              usedPercent:
-                type: number
-              freePercent:
-                type: number
+              history:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - time
+                  - ops
+                  properties:
+                    time:
+                      type: string
+                      format: date-time
+                    ops:
+                      type: number
         msg:
           type: string
           example: fetch metrics successfully
@@ -3135,20 +3569,31 @@ components:
             required:
             - id
             - name
-            - usage
-            - usedPercent
-            - freePercent
+            - device
+            - packets
+            - history
             properties:
               id:
                 type: string
               name:
                 type: string
-              usage:
+              device:
+                type: string
+              packets:
                 type: number
-              usedPercent:
-                type: number
-              freePercent:
-                type: number
+              history:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - time
+                  - packets
+                  properties:
+                    time:
+                      type: string
+                      format: date-time
+                    packets:
+                      type: number
         msg:
           type: string
           example: fetch metrics successfully
@@ -3172,20 +3617,31 @@ components:
             required:
             - id
             - name
-            - usage
-            - usedPercent
-            - freePercent
+            - device
+            - packets
+            - history
             properties:
               id:
                 type: string
               name:
                 type: string
-              usage:
+              device:
+                type: string
+              packets:
                 type: number
-              usedPercent:
-                type: number
-              freePercent:
-                type: number
+              history:
+                type: array
+                items:
+                  type: object
+                  required:
+                  - time
+                  - packets
+                  properties:
+                    time:
+                      type: string
+                      format: date-time
+                    packets:
+                      type: number
         msg:
           type: string
           example: fetch metrics successfully


### PR DESCRIPTION
### What type of PR is this?

Feat and refactor

📔 The changes in this PR are only for metric APIs(used by chart ui), so shouldn't impact the home, login/out, or other pages.

📔 The changes haven't been deployed to the 10.113:4443, will be deployed after finished the review.

<br/>

### Which issue(s) this PR fixes?

major: charts related 

- https://github.com/bigstack-oss/cube-cos-api/issues/45

- https://github.com/bigstack-oss/cube-cos-api/issues/46

- https://github.com/bigstack-oss/cube-cos-api/issues/47

<br/>

minor: data center related

- https://github.com/bigstack-oss/cube-cos-api/issues/16


<br/>


### What this PR does?

major: charts related 

- adjust/enrich more resource usage info for newly designed chart ui like per node resource usage and appending historical data with ranking list

- the 4th iterated ranking schema can bring a few convenience to FE devs without any of perf concern, but it's also okay if they want to call different apis to concat the data.

<br>

minor: data center related

- add the missed additional help url info


<br/>


### Test results (optional)

- has checked the doc by validation tool

![Screenshot 2025-02-14 at 3 20 16 AM](https://github.com/user-attachments/assets/716c634f-14af-4013-9115-7d8fdb11bc48)

- can see the video below to quick go through the newly changed part of metric apis

https://github.com/user-attachments/assets/bdbbb11a-4213-4e8a-9571-e3cb8101d7de



