### PR TITLE
feat(metrics): add metrics api watch query support

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -384,14 +384,7 @@ paths:
           type: integer
         description: The size per page of the events to return (default is unlimit).
         example: 10
-      - in: query
-        name: watch
-        required: false
-        schema:
-          type: boolean
-        description: The toggle to enable http chunked transfer for continues server
-          push.
-        example: true
+      - $ref: '#/components/parameters/watchParam'
       responses:
         '200':
           description: Retrieve the list of events successfully
@@ -567,14 +560,7 @@ paths:
           type: integer
         description: The limit of the abstracted events to return (default is 10).
         example: 10
-      - in: query
-        name: watch
-        required: false
-        schema:
-          type: boolean
-        description: The toggle to enable http chunked transfer for continues server
-          push.
-        example: true
+      - $ref: '#/components/parameters/watchParam'
       responses:
         '200':
           description: Retrieve the abstracted events successfully
@@ -834,14 +820,7 @@ paths:
           type: integer
         description: The limit of the rank of event to return (default is 10).
         example: 10
-      - in: query
-        name: watch
-        required: false
-        schema:
-          type: boolean
-        description: The toggle to enable http chunked transfer for continues server
-          push.
-        example: true
+      - $ref: '#/components/parameters/watchParam'
       responses:
         '200':
           description: Retrieve the rank of event successfully
@@ -915,14 +894,7 @@ paths:
           type: string
         description: The name of the data center to operate
         example: example-data-center
-      - in: query
-        name: watch
-        required: false
-        schema:
-          type: boolean
-        description: The toggle to enable http chunked transfer for continues server
-          push.
-        example: true
+      - $ref: '#/components/parameters/watchParam'
       responses:
         '200':
           description: Retrieve the list of health successfully
@@ -1097,14 +1069,7 @@ paths:
           - notifications
         description: The name of the service to retrieve health history. use GET /api/v1/datacenters/{dataCenter}/services
           to get the service list and their modules.
-      - in: query
-        name: watch
-        required: false
-        schema:
-          type: boolean
-        description: The toggle to enable http chunked transfer for continues server
-          push.
-        example: true
+      - $ref: '#/components/parameters/watchParam'
       responses:
         '200':
           description: Retrieve the health history of service successfully
@@ -1403,14 +1368,7 @@ paths:
         description: The end time of the health history to query, the value should
           be in RFC3339 format (default is now).
         example: '2025-01-01T01:00:00Z'
-      - in: query
-        name: watch
-        required: false
-        schema:
-          type: boolean
-        description: The toggle to enable http chunked transfer for continues server
-          push.
-        example: true
+      - $ref: '#/components/parameters/watchParam'
       responses:
         '200':
           description: Retrieve the health history of module successfully
@@ -1908,14 +1866,7 @@ paths:
           type: string
         description: The name of the data center to operate
         example: example-data-center
-      - in: query
-        name: watch
-        required: false
-        schema:
-          type: boolean
-        description: The toggle to enable http chunked transfer for continues server
-          push.
-        example: true
+      - $ref: '#/components/parameters/watchParam'
       responses:
         '200':
           description: Retrieve the summary of data center successfully
@@ -2101,14 +2052,7 @@ paths:
         description: The end time of the event to query, the value should be in RFC3339
           format (default is now).
         example: '2025-01-01T01:00:00Z'
-      - in: query
-        name: watch
-        required: false
-        schema:
-          type: boolean
-        description: The toggle to enable http chunked transfer for continues server
-          push.
-        example: true
+      - $ref: '#/components/parameters/watchParam'
       responses:
         '200':
           description: Retrieve the summary of data center successfully
@@ -2755,14 +2699,7 @@ paths:
           type: integer
         description: The size per page of the events to return (default is unlimit).
         example: 10
-      - in: query
-        name: watch
-        required: false
-        schema:
-          type: boolean
-        description: The toggle to enable http chunked transfer for continues server
-          push.
-        example: true
+      - $ref: '#/components/parameters/watchParam'
       responses:
         '200':
           description: Retrieve the list of nodes successfully
@@ -5947,3 +5884,12 @@ components:
         status:
           type: string
           example: ok
+  parameters:
+    watchParam:
+      in: query
+      name: watch
+      required: false
+      schema:
+        type: boolean
+      description: The toggle to enable http chunked transfer for continuous server push.
+      example: true


### PR DESCRIPTION
### What type of PR is this?

Feat and refactor

### Which issue(s) this PR fixes?

The COS Home Page and Chart Page need to continuously receive real-time updates or refresh data at regular intervals.
Therefore, I added a watch query to the metrics APIs to support this feature.

<img width="799" alt="Screenshot 2025-02-28 at 12 19 21 AM" src="https://github.com/user-attachments/assets/8d216d72-058c-403a-ad0d-c1228833752b" />
<img width="607" alt="Screenshot 2025-02-28 at 12 19 59 AM" src="https://github.com/user-attachments/assets/0e66fedc-55e1-446e-a43c-54bfff072d15" />


### What this PR does?

feat: add watch query for the Metrics APIs:

-  GET `/api/v1/datacenters/{dataCenter}/metrics
-  GET `/api/v1/datacenters/{dataCenter}/metrics/{metricType}/{viewType}/{entityType}`

<img width="721" alt="Screenshot 2025-02-28 at 12 08 53 AM" src="https://github.com/user-attachments/assets/7a9d7562-4c24-4c2f-92fd-c06f65a00de9" />

<img width="727" alt="Screenshot 2025-02-28 at 12 09 09 AM" src="https://github.com/user-attachments/assets/f0331dcf-f0a1-4f56-bc89-8df9095dc545" />

refactor: extract the `watchParam` to `components/parameter` to improve maintainability.

Definition:
<img width="689" alt="image" src="https://github.com/user-attachments/assets/9b29b947-c074-4cae-9b9d-647963ea037d" />

Usage:
<img width="1826" alt="Screenshot 2025-02-28 at 12 18 25 AM" src="https://github.com/user-attachments/assets/43771af3-879e-4c11-8407-d1402063a6e1" />

@jdjgya if you think it's not the right time to extract this query, feel free to drop the second commit 🙏
reference:  https://swagger.io/docs/specification/v3_0/components/#components-example

### Test results (optional)

<img width="216" alt="image" src="https://github.com/user-attachments/assets/042032d4-e4f8-4f29-9209-0454b76f08f1" />
