### PR TITLE
refactor(health): define health status enum

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -3885,6 +3885,7 @@ components:
                   properties:
                     current:
                       type: string
+                      enum: ['ok', 'ng']
                     isFixing:
                       type: boolean
                     description:
@@ -3912,6 +3913,7 @@ components:
                       current:
                         type: string
                         example: ok
+                        enum: ['ok', 'ng']
                   modules:
                     type: array
                     required:
@@ -3934,6 +3936,7 @@ components:
                             current:
                               type: string
                               example: ok
+                              enum: ['ok', 'ng']
         msg:
           type: string
           example: fetch health successfully
@@ -3977,6 +3980,7 @@ components:
                       format: date-time
                     status:
                       type: string
+                      enum: ['ok', 'ng']
                     error:
                       type: object
                       properties:
@@ -4069,6 +4073,7 @@ components:
                     format: date-time
                   status:
                     type: string
+                    enum: ['ok', 'ng']
                   error:
                     type: object
                     properties:


### PR DESCRIPTION
⚠️ This PR is based on https://github.com/bigstack-oss/cube-cos-openapi/pull/4 branch. 
⚠️ So just review last commit and merge this PR after the https://github.com/bigstack-oss/cube-cos-openapi/pull/4 is merged.

---

### What type of PR is this?

Refactor

### Which issue(s) this PR fixes?

N/A

### What this PR does?

refactor: define an enum for health status

Currently,  COS health status only inlcudes `ok` and `ng`.
To make it more precise than using string, defined an enum for the health status.

If there are other possible statuses besides `ok` or `ng`, feel free to add the missing states or close this PR. Thanks!

### Test results (optional)

<img width="244" alt="image" src="https://github.com/user-attachments/assets/4afdf894-e4bd-4709-ba84-506f3257fb3c" />


https://github.com/user-attachments/assets/c26e64c5-44d9-4ae5-8777-297a2d5662b5
