### PR TITLE
fix(node): license expiry field incorrect name

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -5372,7 +5372,7 @@ components:
                     - product
                     - issue
                     - serviceLevelAgreement
-                    - expire
+                    - expiry
                     properties:
                       status:
                         type: string
@@ -5418,7 +5418,6 @@ components:
                         - period
                         - meanTimeBetweenFailure
                         - meanTimeToRepair
-                        - expire
                         properties:
                           uptime:
                             type: number
@@ -5428,7 +5427,7 @@ components:
                             type: string
                           meanTimeToRepair:
                             type: string
-                      expire:
+                      expiry:
                         type: object
                         required:
                         - date


### PR DESCRIPTION
### What type of PR is this?

Fix

### Which issue(s) this PR fixes?

N/A

### What this PR does?

fix(node): license expiry field incorrect name: `expire` => `expiry`

### Test results (optional)

<img width="226" alt="Screenshot 2025-02-28 at 1 18 06 AM" src="https://github.com/user-attachments/assets/920147cf-7c24-4995-b382-2f26ab826142" />

<img width="678" alt="Screenshot 2025-02-28 at 1 19 23 AM" src="https://github.com/user-attachments/assets/0f2f8d9b-5fbf-499f-a451-3d04c6033341" />

