### PR TITLE
ci: openapi validation

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -1,0 +1,22 @@
+name: CI workflow
+
+on:
+  pull_request:
+    branches: ['develop']
+
+jobs:
+  validate:
+    name: Validate OpenAPI Spec
+    runs-on: ubuntu-latest
+    container:
+      # Use the Docker image to avoid setting up the JVM environment and make it easier to use.
+      # reference: https://github.com/OpenAPITools/openapi-generator?tab=readme-ov-file#16---docker
+      image: docker.io/openapitools/openapi-generator-cli:v7.11.0
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+
+      - name: validate
+        # Entrypoint file location:
+        # https://github.com/OpenAPITools/openapi-generator/blob/a79aad84206502d9cb212495520756cc82453769/Dockerfile#L38C45-L38C47
+        run: /usr/local/bin/docker-entrypoint.sh validate -i ./docs.yaml


### PR DESCRIPTION
### What type of PR is this?

CI

### Which issue(s) this PR fixes?

N/A

### What this PR does?

Add a validation CI using the [openapi-generator-cli](https://hub.docker.com/r/openapitools/openapi-generator-cli) Docker image to eliminate the need for manually executing `./script/validate.sh` every time developers make changes to the code on their local machines.

### Test results (optional)

I misspelled the `GetDataCentersResponse` ref, which caused the validation to fail the PR.

<img width="1594" alt="Screenshot 2025-02-28 at 5 52 25 PM" src="https://github.com/user-attachments/assets/80b1f722-849f-4f27-b118-b6b4fcd37dde" />
<img width="1909" alt="Screenshot 2025-02-28 at 5 51 42 PM" src="https://github.com/user-attachments/assets/18164310-6c6a-4717-9e23-01975a1c72be" />

https://github.com/bigstack-oss/cube-cos-openapi/actions/runs/13585602443/job/37979749518?pr=10
