### PR TITLE
fix: get services response service name field issue

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -3564,11 +3564,11 @@ components:
           items:
             type: object
             required:
-            - service
+            - name
             - category
             - modules
             properties:
-              service:
+              name:
                 type: string
               category:
                 type: string


### PR DESCRIPTION
### What type of PR is this?

Fix

### Which issue(s) this PR fixes?

N/A

### What this PR does?

For service names in `GetServicesResponse`, the property should be `name` instead of `service`.

### Test results (optional)

<img width="760" alt="{1B8D7800-5DCC-4E59-9B20-D987C3E99623}" src="https://github.com/user-attachments/assets/01026206-c7b7-4911-b551-b26a76f0592c" />
