### PR TITLE
fix(metrics): get metrics by types api missing watch query

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -2157,6 +2157,7 @@ paths:
         description: The end time of the event to query, the value should be in RFC3339
           format (default is now).
         example: '2025-01-01T01:00:00+00:00'
+      - $ref: "#/components/parameters/watch"
       responses:
         '200':
           description: Retrieve the summary of data center successfully


### PR DESCRIPTION
### What type of PR is this?

Fix

### Which issue(s) this PR fixes?

fix(metrics): get metrics by types api missing watch query

### What this PR does?

Currently, the backend already implemented the stream support for getMetricsByTypes API.
So I added the missing watch query in the OpenAPI doc:

<img width="707" alt="Screenshot 2025-03-11 at 2 12 14 PM" src="https://github.com/user-attachments/assets/5fa7fd0d-a600-4c69-9094-55bca5fe1b68" />

### Test results (optional)

N/A
