### PR TITLE
Add api docs for settings, tunings, triggers, nodes, and support files related apis

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -1790,13 +1790,6 @@ paths:
       summary: Update licenses for the cluster
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
-      - in: path
-        name: node
-        required: true
-        schema:
-          type: string
-        description: The name of the node to operate
-        example: example-node
       requestBody:
         required: true
         content:
@@ -3340,6 +3333,13 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       - "$ref": "#/components/parameters/watch"
+      - name: nodeName
+        in: path
+        description: The name of the node
+        required: true
+        schema:
+          type: string
+        example: example-node-0
       responses:
         '200':
           description: Retrieve the node details successfully
@@ -6142,6 +6142,8 @@ paths:
                         emails:
                         - address: example.user@example.com
                           note: example email recipient
+                      status:
+                        isUpdating: false
                       enabled: false
                     - name: Instance Level Notification
                       description: Configure how you are going to be notified for
@@ -6201,6 +6203,8 @@ paths:
                         emails:
                         - address: example.user@example.com
                           note: example email recipient
+                      status:
+                        isUpdating: false
                       enabled: false
                     msg: fetch triggers successfully
                     status: ok
@@ -6669,10 +6673,10 @@ paths:
                     example: internal server error
   "/api/v1/datacenters/{dataCenter}/grafana/hosts/{hostname}":
     get:
-      operationId: fowardToGrafanaHosts
+      operationId: getGrafanaHosts
       tags:
       - Grafana
-      summary: Forward to Grafana hosts dashboard
+      summary: Get Grafana hosts dashboard
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       - in: path
@@ -6683,13 +6687,21 @@ paths:
         description: The hostname of the host to operate
         example: example-node-0
       responses:
-        '302':
-          description: Forward to Grafana hosts dashboard
-          headers:
-            Location:
+        '200':
+          description: Get Grafana hosts dashboard
+          content:
+            application/json:
               schema:
-                type: string
-                example: http://example-data-center/grafana/d/i-R2q81iz/host?refresh=5m&kiosk=tv&orgId=1&var-HOST=example-node-0
+                "$ref": "#/components/schemas/GetGrafanaDashboardLinkResponse"
+              examples:
+                example:
+                  summary: Grafana hosts dashboard link
+                  value:
+                    code: 200
+                    data:
+                      link: http://example-data-center/grafana/d/i-R2q81iz/host?refresh=5m&kiosk=tv&orgId=1&var-HOST=example-node-0
+                    msg: fetch top host link successfully
+                    status: ok
         '401':
           description: Unauthorized
           content:
@@ -6718,17 +6730,17 @@ paths:
                     example: 500
                   msg:
                     type: string
-                    example: 'failed to forward Grafana hosts dashboard: internal
-                      server error'
+                    example: 'failed to get Grafana hosts dashboard: internal server
+                      error'
                   status:
                     type: string
                     example: internal server error
   "/api/v1/datacenters/{dataCenter}/grafana/instances/{instanceId}":
     get:
-      operationId: fowardToGrafanaInstances
+      operationId: getGrafanaInstances
       tags:
       - Grafana
-      summary: Forward to Grafana instances dashboard
+      summary: Get Grafana instances dashboard
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       - in: path
@@ -6739,13 +6751,21 @@ paths:
         description: The instance ID of the instance to operate
         example: example-instance-id
       responses:
-        '302':
-          description: Forward to Grafana instances dashboard
-          headers:
-            Location:
+        '200':
+          description: Get Grafana instances dashboard
+          content:
+            application/json:
               schema:
-                type: string
-                example: http://example-data-center/grafana/d/PVW6vU7Wz/instance?refresh=5m&kiosk=tv&orgId=1&var-UUID=example-instance-id
+                "$ref": "#/components/schemas/GetGrafanaDashboardLinkResponse"
+              examples:
+                example:
+                  summary: Grafana instances dashboard link
+                  value:
+                    code: 200
+                    data:
+                      link: http://example-data-center/grafana/d/qzfq087Wk/instance?refresh=5m&orgId=1&var-TID=example-instance-id&var-TOP=50&var-TENANT=admin
+                    msg: fetch top instance link successfully
+                    status: ok
         '401':
           description: Unauthorized
           content:
@@ -6774,27 +6794,35 @@ paths:
                     example: 500
                   msg:
                     type: string
-                    example: 'failed to forward Grafana instances dashboard: internal
+                    example: 'failed to get Grafana instances dashboard: internal
                       server error'
                   status:
                     type: string
                     example: internal server error
   "/api/v1/datacenters/{dataCenter}/grafana/topHosts":
     get:
-      operationId: fowardToGrafanaTopHosts
+      operationId: getGrafanaTopHosts
       tags:
       - Grafana
-      summary: Forward to Grafana top hosts dashboard
+      summary: Get Grafana top hosts dashboard
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       responses:
-        '302':
-          description: Forward to Grafana top hosts dashboard
-          headers:
-            Location:
+        '200':
+          description: Get Grafana top hosts dashboard
+          content:
+            application/json:
               schema:
-                type: string
-                example: http://example-data-center/grafana/d/M3ncw6lmk/top-hosts?refresh=5m&kiosk=tv&orgId=1
+                "$ref": "#/components/schemas/GetGrafanaDashboardLinkResponse"
+              examples:
+                example:
+                  summary: Grafana top hosts dashboard link
+                  value:
+                    code: 200
+                    data:
+                      link: http://example-data-center/grafana/d/M3ncw6lmk/top-hosts?refresh=5m&kiosk=tv&orgId=1
+                    msg: fetch top host link successfully
+                    status: ok
         '401':
           description: Unauthorized
           content:
@@ -6823,27 +6851,35 @@ paths:
                     example: 500
                   msg:
                     type: string
-                    example: 'failed to forward Grafana top hosts dashboard: internal
+                    example: 'failed to get Grafana top hosts dashboard: internal
                       server error'
                   status:
                     type: string
                     example: internal server error
   "/api/v1/datacenters/{dataCenter}/grafana/topInstances":
     get:
-      operationId: fowardToGrafanaTopInstances
+      operationId: getGrafanaTopInstances
       tags:
       - Grafana
-      summary: Forward to Grafana top instances dashboard
+      summary: Get Grafana top instances dashboard
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       responses:
-        '302':
-          description: Forward to Grafana top instances dashboard
-          headers:
-            Location:
+        '200':
+          description: Get Grafana top instances dashboard
+          content:
+            application/json:
               schema:
-                type: string
-                example: http://example-data-center/grafana/d/qzfq087Wk/top-instances?refresh=5m&orgId=1&var-TID=&var-TOP=50&var-TENANT=admin
+                "$ref": "#/components/schemas/GetGrafanaDashboardLinkResponse"
+              examples:
+                example:
+                  summary: Grafana top instances dashboard link
+                  value:
+                    code: 200
+                    data:
+                      link: http://example-data-center/grafana/d/qzfq087Wk/top-instances?refresh=5m&orgId=1&var-TID=&var-TOP=50&var-TENANT=admin
+                    msg: fetch top instance link successfully
+                    status: ok
         '401':
           description: Unauthorized
           content:
@@ -6872,27 +6908,35 @@ paths:
                     example: 500
                   msg:
                     type: string
-                    example: 'failed to forward Grafana top instances dashboard: internal
+                    example: 'failed to get Grafana top instances dashboard: internal
                       server error'
                   status:
                     type: string
                     example: internal server error
   "/api/v1/datacenters/{dataCenter}/grafana/networks":
     get:
-      operationId: fowardToGrafanaNetworks
+      operationId: getGrafanaNetworks
       tags:
       - Grafana
-      summary: Forward to Grafana networks dashboard
+      summary: Get Grafana networks dashboard
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       responses:
-        '302':
-          description: Forward to Grafana networks dashboard
-          headers:
-            Location:
+        '200':
+          description: Get Grafana networks dashboard
+          content:
+            application/json:
               schema:
-                type: string
-                example: http://example-data-center/grafana/d/Xx2kkftWk/network?orgId=1&refresh=5m
+                "$ref": "#/components/schemas/GetGrafanaDashboardLinkResponse"
+              examples:
+                example:
+                  summary: Grafana networks dashboard link
+                  value:
+                    code: 200
+                    data:
+                      link: http://example-data-center/grafana/d/Xx2kkftWk/network?orgId=1&refresh=5m
+                    msg: fetch top network link successfully
+                    status: ok
         '401':
           description: Unauthorized
           content:
@@ -6921,27 +6965,35 @@ paths:
                     example: 500
                   msg:
                     type: string
-                    example: 'failed to forward Grafana networks dashboard: internal
-                      server error'
+                    example: 'failed to get Grafana networks dashboard: internal server
+                      error'
                   status:
                     type: string
                     example: internal server error
   "/api/v1/datacenters/{dataCenter}/grafana/storages":
     get:
-      operationId: fowardToGrafanaStorages
+      operationId: getGrafanaStorages
       tags:
       - Grafana
-      summary: Forward to Grafana storages dashboard
+      summary: Get Grafana storages dashboard
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       responses:
-        '302':
-          description: Forward to Grafana storages dashboard
-          headers:
-            Location:
+        '200':
+          description: Get Grafana storages dashboard
+          content:
+            application/json:
               schema:
-                type: string
-                example: http://example-data-center/grafana/d/QTc_sAxiw/storage?refresh=5m&kiosk=tv&orgId=1
+                "$ref": "#/components/schemas/GetGrafanaDashboardLinkResponse"
+              examples:
+                example:
+                  summary: Grafana storages dashboard link
+                  value:
+                    code: 200
+                    data:
+                      link: http://example-data-center/grafana/d/QTc_sAxiw/storage?refresh=5m&kiosk=tv&orgId=1
+                    msg: fetch top storage link successfully
+                    status: ok
         '401':
           description: Unauthorized
           content:
@@ -6970,8 +7022,8 @@ paths:
                     example: 500
                   msg:
                     type: string
-                    example: 'failed to forward Grafana storages dashboard: internal
-                      server error'
+                    example: 'failed to get Grafana storages dashboard: internal server
+                      error'
                   status:
                     type: string
                     example: internal server error
@@ -8766,7 +8818,7 @@ components:
             slack:
               type: object
               properties:
-                channel:
+                channels:
                   "$ref": "#/components/schemas/SlackChannelPostRequest"
         msg:
           type: string
@@ -9289,6 +9341,7 @@ components:
             - description
             - attributes
             - response
+            - status
             - enabled
             properties:
               name:
@@ -9349,6 +9402,15 @@ components:
                           type: string
                         note:
                           type: string
+              status:
+                type: object
+                required:
+                - isUpdating
+                properties:
+                  current:
+                    type: string
+                  isUpdating:
+                    type: boolean
               enabled:
                 type: boolean
         msg:
@@ -9528,6 +9590,27 @@ components:
       properties:
         code:
           type: integer
+        msg:
+          type: string
+        status:
+          type: string
+    GetGrafanaDashboardLinkResponse:
+      type: object
+      required:
+      - code
+      - data
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+        data:
+          type: object
+          required:
+          - link
+          properties:
+            link:
+              type: string
         msg:
           type: string
         status:

--- a/docs.yaml
+++ b/docs.yaml
@@ -409,20 +409,8 @@ paths:
         description: The end time of the event to query, the value should be in RFC3339
           format (default is now).
         example: '2025-01-01T01:00:00+00:00'
-      - in: query
-        name: pageNum
-        required: false
-        schema:
-          type: integer
-        description: The page number of the event chunking to fetch (default is 1).
-        example: 1
-      - in: query
-        name: pageSize
-        required: false
-        schema:
-          type: integer
-        description: The size per page of the events to return (default is unlimit).
-        example: 10
+      - "$ref": "#/components/parameters/pageSize"
+      - "$ref": "#/components/parameters/pageNum"
       - "$ref": "#/components/parameters/watch"
       responses:
         '200':
@@ -1734,20 +1722,8 @@ paths:
       summary: Retrieve the list of licenses
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
-      - in: query
-        name: pageNum
-        required: false
-        schema:
-          type: integer
-        description: The page number of the event chunking to fetch (default is 1).
-        example: 1
-      - in: query
-        name: pageSize
-        required: false
-        schema:
-          type: integer
-        description: The size per page of the events to return (default is unlimit).
-        example: 10
+      - "$ref": "#/components/parameters/pageSize"
+      - "$ref": "#/components/parameters/pageNum"
       responses:
         '200':
           description: Retrieve the list of licenses successfully
@@ -1788,6 +1764,7 @@ paths:
                         total: 1
                         number: 1
                         size: 1
+                        totalItemCount: 1
                     msg: fetch licenses successfully
                     status: ok
         '500':
@@ -2160,7 +2137,8 @@ paths:
       - $ref: "#/components/parameters/watch"
       responses:
         '200':
-          description: Retrieve the summary of data center successfully
+          description: Retrieve the various metrics with different view from hosts
+            or vms
           content:
             application/json:
               schema:
@@ -2714,20 +2692,8 @@ paths:
       summary: Retrieve the list of nodes
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
-      - in: query
-        name: pageNum
-        required: false
-        schema:
-          type: integer
-        description: The page number of the event chunking to fetch (default is 1).
-        example: 1
-      - in: query
-        name: pageSize
-        required: false
-        schema:
-          type: integer
-        description: The size per page of the events to return (default is unlimit).
-        example: 10
+      - "$ref": "#/components/parameters/pageSize"
+      - "$ref": "#/components/parameters/pageNum"
       - "$ref": "#/components/parameters/watch"
       responses:
         '200':
@@ -2744,13 +2710,15 @@ paths:
                     data:
                       nodes:
                       - id: abc0005e
-                        hostname: example-node
+                        dataCenter: example-data-center
+                        hostname: example-node-0
                         role: control-converged
                         address: 10.10.10.10:8001
+                        ip: 10.10.10.10
                         managementIP: 10.10.10.10
                         license:
                           type: trial
-                          hostname: example-node
+                          hostname: example-node-0
                           serial: 1H2ZLG2
                           product:
                             name: ''
@@ -2759,7 +2727,7 @@ paths:
                             by: Bigstack co., ltd.
                             to: bigstack
                             hardware: "*"
-                            date: '2025-02-04T17:54:45+08:00'
+                            date: '2025-01-23T14:51:50+08:00'
                           quantity:
                             type: ''
                             vcpu: 0
@@ -2769,34 +2737,582 @@ paths:
                             meanTimeBetweenFailure: ''
                             meanTimeToRecovery: ''
                           expiry:
-                            date: '2025-04-05T17:54:45+08:00'
-                            days: 44
+                            date: '2025-03-24T14:51:50+08:00'
+                            days: 9
                         status: up
+                        cpuSpec: Intel(R) Xeon(R) CPU E5-2650 v4 @ 2.20GHz
+                        networkInterfaces:
+                        - label: IF.1
+                          busIdSlaves: '0000:01:00.0'
+                          driver: tg3
+                          state: UP
+                          speed: 1000F/1000F
+                        - label: IF.2
+                          busIdSlaves: '0000:01:00.1'
+                          driver: tg3
+                          state: DOWN
+                          speed: NA/1000F
+                        - label: IF.3
+                          busIdSlaves: '0000:02:00.0'
+                          driver: tg3
+                          state: DOWN
+                          speed: NA/1000F
+                        - label: IF.4
+                          busIdSlaves: '0000:02:00.1'
+                          driver: tg3
+                          state: DOWN
+                          speed: NA/1000F
+                        blockDevices:
+                        - device: nbd0
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd1
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd10
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd11
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd12
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd13
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd14
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd15
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd2
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd3
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd4
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd5
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd6
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd7
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd8
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: nbd9
+                          type: disk
+                          sizeMiB: 0
+                          status: available
+                        - device: sda
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sda1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sda2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sda3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sda4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdb
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdb1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdb2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdb3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdb4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdc
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdc1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdc2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdc3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdc4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdd
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdd1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdd2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdd3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdd4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sde
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sde1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sde2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sde3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sde4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdf
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdf1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdf2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdf3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdf4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdg
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdg1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdg2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdg3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdg4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdh
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdh1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdh2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdh3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdh4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdi
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdi1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdi2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdi3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdi4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdj
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdj1
+                          type: part
+                          sizeMiB: 953.6743
+                          status: storage
+                        - device: sdj5
+                          type: part
+                          sizeMiB: 239467.6208
+                          status: storage
+                        - device: sdj6
+                          type: part
+                          sizeMiB: 239467.6208
+                          status: available
+                        - device: sdj7
+                          type: part
+                          sizeMiB: 53215.0268
+                          status: storage
+                        - device: sdk
+                          type: disk
+                          sizeMiB: 532531.7382
+                          status: available
+                        - device: sdk1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdk2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdk3
+                          type: part
+                          sizeMiB: 265884.3994
+                          status: available
+                        - device: sdk4
+                          type: part
+                          sizeMiB: 265884.3994
+                          status: available
+                        - device: sdl
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdl1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdl2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdl3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdl4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdm
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdm1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdm2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdm3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdm4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdn
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdn1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdn2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdn3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdn4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdo
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdo1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdo2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdo3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdo4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdp
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdp1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdp2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdp3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdp4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdq
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdq1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdq2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdq3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdq4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdr
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdr1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdr2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdr3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdr4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sds
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sds1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sds2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sds3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sds4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdt
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdt1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdt2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdt3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdt4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdu
+                          type: disk
+                          sizeMiB: 533008.5754
+                          status: available
+                        - device: sdu1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdu2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdu3
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdu4
+                          type: part
+                          sizeMiB: 266170.5017
+                          status: available
+                        - device: sdv
+                          type: disk
+                          sizeMiB: 532531.7382
+                          status: available
+                        - device: sdv1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdv2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdv3
+                          type: part
+                          sizeMiB: 265884.3994
+                          status: available
+                        - device: sdv4
+                          type: part
+                          sizeMiB: 265884.3994
+                          status: available
+                        - device: sdw
+                          type: disk
+                          sizeMiB: 532531.7382
+                          status: available
+                        - device: sdw1
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdw2
+                          type: part
+                          sizeMiB: 381.4697
+                          status: storage
+                        - device: sdw3
+                          type: part
+                          sizeMiB: 265884.3994
+                          status: available
+                        - device: sdw4
+                          type: part
+                          sizeMiB: 265884.3994
+                          status: available
                         vcpu:
                           totalCores: 48
-                          usedCores: 38
-                          usedPercent: 79.1666
-                          freeCores: 10
-                          freePercent: 20.8333
+                          usedCores: 40
+                          usedPercent: 83.3333
+                          freeCores: 8
+                          freePercent: 16.6666
                         memory:
                           totalMiB: 257822
-                          usedMiB: 95400
-                          usedPercent: 37.0022
-                          freeMiB: 162422
-                          freePercent: 62.9977
+                          usedMiB: 100520
+                          usedPercent: 38.9881
+                          freeMiB: 157302
+                          freePercent: 61.0118
                         storage:
                           totalMiB: 12571648
-                          usedMiB: 716800
-                          usedPercent: 5.7017
-                          freeMiB: 11854848
-                          freePercent: 94.2982
-                        uptimeSeconds: 5734686.37
+                          usedMiB: 1126400
+                          usedPercent: 8.9598
+                          freeMiB: 11445248
+                          freePercent: 91.0401
+                        uptimeSeconds: 2461586.74
                         labels:
                           isGpuEnabled: 'false'
                       page:
                         total: 1
                         number: 1
                         size: 1
+                        totalItemCount: 1
                     msg: fetch nodes list successfully
                     status: ok
         '500':
@@ -2812,6 +3328,645 @@ paths:
                   msg:
                     type: string
                     example: 'failed to fetch nodes: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}":
+    get:
+      operationId: getNode
+      tags:
+      - Nodes
+      summary: Retrieve the node details
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/watch"
+      responses:
+        '200':
+          description: Retrieve the node details successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GetNodeResponse"
+              examples:
+                example:
+                  summary: Node
+                  value:
+                    code: 200
+                    data:
+                      id: abc0005e
+                      dataCenter: example-data-center
+                      hostname: example-node-0
+                      role: control-converged
+                      address: 10.10.10.10:8001
+                      ip: 10.10.10.10
+                      managementIP: 10.10.10.10
+                      license:
+                        type: trial
+                        hostname: example-node-0
+                        serial: 1H2ZLG2
+                        product:
+                          name: ''
+                          features: 
+                        issue:
+                          by: Bigstack co., ltd.
+                          to: bigstack
+                          hardware: "*"
+                          date: '2025-01-23T14:51:50+08:00'
+                        quantity:
+                          type: ''
+                          vcpu: 0
+                        serviceLevelAgreement:
+                          uptime: 0
+                          period: ''
+                          meanTimeBetweenFailure: ''
+                          meanTimeToRecovery: ''
+                        expiry:
+                          date: '2025-03-24T14:51:50+08:00'
+                          days: 9
+                      status: up
+                      cpuSpec: Intel(R) Xeon(R) CPU E5-2650 v4 @ 2.20GHz
+                      networkInterfaces:
+                      - label: IF.1
+                        busIdSlaves: '0000:01:00.0'
+                        driver: tg3
+                        state: UP
+                        speed: 1000F/1000F
+                      - label: IF.2
+                        busIdSlaves: '0000:01:00.1'
+                        driver: tg3
+                        state: DOWN
+                        speed: NA/1000F
+                      - label: IF.3
+                        busIdSlaves: '0000:02:00.0'
+                        driver: tg3
+                        state: DOWN
+                        speed: NA/1000F
+                      - label: IF.4
+                        busIdSlaves: '0000:02:00.1'
+                        driver: tg3
+                        state: DOWN
+                        speed: NA/1000F
+                      blockDevices:
+                      - device: nbd0
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd1
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd10
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd11
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd12
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd13
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd14
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd15
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd2
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd3
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd4
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd5
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd6
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd7
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd8
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: nbd9
+                        type: disk
+                        sizeMiB: 0
+                        status: available
+                      - device: sda
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sda1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sda2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sda3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sda4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdb
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdb1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdb2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdb3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdb4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdc
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdc1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdc2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdc3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdc4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdd
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdd1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdd2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdd3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdd4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sde
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sde1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sde2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sde3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sde4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdf
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdf1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdf2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdf3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdf4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdg
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdg1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdg2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdg3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdg4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdh
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdh1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdh2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdh3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdh4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdi
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdi1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdi2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdi3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdi4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdj
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdj1
+                        type: part
+                        sizeMiB: 953.6743
+                        status: storage
+                      - device: sdj5
+                        type: part
+                        sizeMiB: 239467.6208
+                        status: storage
+                      - device: sdj6
+                        type: part
+                        sizeMiB: 239467.6208
+                        status: available
+                      - device: sdj7
+                        type: part
+                        sizeMiB: 53215.0268
+                        status: storage
+                      - device: sdk
+                        type: disk
+                        sizeMiB: 532531.7382
+                        status: available
+                      - device: sdk1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdk2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdk3
+                        type: part
+                        sizeMiB: 265884.3994
+                        status: available
+                      - device: sdk4
+                        type: part
+                        sizeMiB: 265884.3994
+                        status: available
+                      - device: sdl
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdl1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdl2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdl3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdl4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdm
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdm1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdm2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdm3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdm4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdn
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdn1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdn2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdn3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdn4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdo
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdo1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdo2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdo3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdo4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdp
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdp1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdp2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdp3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdp4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdq
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdq1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdq2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdq3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdq4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdr
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdr1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdr2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdr3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdr4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sds
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sds1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sds2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sds3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sds4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdt
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdt1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdt2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdt3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdt4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdu
+                        type: disk
+                        sizeMiB: 533008.5754
+                        status: available
+                      - device: sdu1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdu2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdu3
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdu4
+                        type: part
+                        sizeMiB: 266170.5017
+                        status: available
+                      - device: sdv
+                        type: disk
+                        sizeMiB: 532531.7382
+                        status: available
+                      - device: sdv1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdv2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdv3
+                        type: part
+                        sizeMiB: 265884.3994
+                        status: available
+                      - device: sdv4
+                        type: part
+                        sizeMiB: 265884.3994
+                        status: available
+                      - device: sdw
+                        type: disk
+                        sizeMiB: 532531.7382
+                        status: available
+                      - device: sdw1
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdw2
+                        type: part
+                        sizeMiB: 381.4697
+                        status: storage
+                      - device: sdw3
+                        type: part
+                        sizeMiB: 265884.3994
+                        status: available
+                      - device: sdw4
+                        type: part
+                        sizeMiB: 265884.3994
+                        status: available
+                      vcpu:
+                        totalCores: 48
+                        usedCores: 40
+                        usedPercent: 83.3333
+                        freeCores: 8
+                        freePercent: 16.6666
+                      memory:
+                        totalMiB: 257822
+                        usedMiB: 100520
+                        usedPercent: 38.9881
+                        freeMiB: 157302
+                        freePercent: 61.0118
+                      storage:
+                        totalMiB: 12571648
+                        usedMiB: 1126400
+                        usedPercent: 8.9598
+                        freeMiB: 11445248
+                        freePercent: 91.0401
+                      uptimeSeconds: 2461586.74
+                      labels:
+                        isGpuEnabled: 'false'
+                    msg: fetch nodes list successfully
+                    status: ok
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to fetch node: internal server error'
                   status:
                     type: string
                     example: internal server error
@@ -2839,17 +3994,14 @@ paths:
                       titlePrefix: example title prefix
                       email:
                         recipients:
-                        - email: example.user.1@example.com
+                        - address: example.user.1@example.com
                           note: example note 1
-                          isTestable: true
-                        - email: example.user.2@example.com
+                        - address: example.user.2@example.com
                           note: example note 2
-                          isTestable: true
                         senders:
                         - host: email-smtp.example.mailserver.com
                           port: 587
                           username: ABBBBBBMJM56DCCCCJR
-                          password: VBHWEEGEEEEEX0f5NLHDXLESxdZR
                           email: noreply@example.com
                           accessVerified: true
                       slack:
@@ -2933,7 +4085,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/EmailSender"
+              "$ref": "#/components/schemas/EmailSenderPostRequest"
             examples:
               example:
                 summary: Email Sender
@@ -2989,7 +4141,6 @@ paths:
                     - host: email-smtp.example.mailserver.com
                       port: 587
                       username: example-user
-                      password: example-password
                       email: noreply@bigstack.co
                       accessVerified: true
                     msg: email senders retrieved successfully
@@ -3059,7 +4210,7 @@ paths:
                   status:
                     type: string
                     example: internal server error
-    put:
+    patch:
       operationId: updateEmailSender
       tags:
       - Settings
@@ -3078,7 +4229,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/EmailSender"
+              "$ref": "#/components/schemas/EmailSenderPutRequest"
             examples:
               example:
                 summary: Email Sender
@@ -3161,12 +4312,12 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/EmailRecipient"
+              "$ref": "#/components/schemas/EmailRecipientPostRequest"
             examples:
               example:
                 summary: Email Recipient
                 value:
-                  email: example.user.1@example.com
+                  address: example.user.1@example.com
                   note: example email recipient
       responses:
         '201':
@@ -3211,12 +4362,10 @@ paths:
                   value:
                     code: 200
                     data:
-                    - email: example.user.1@example.com
+                    - address: example.user.1@example.com
                       note: example email recipient 1
-                      isTestable: true
-                    - email: example.user.2@example.com
+                    - address: example.user.2@example.com
                       note: example email recipient 2
-                      isTestable: true
                     msg: email recipients retrieved successfully
                     status: ok
         '500':
@@ -3306,12 +4455,12 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/EmailRecipient"
+              "$ref": "#/components/schemas/EmailRecipientPutRequest"
             examples:
               example:
                 summary: Email Recipient
                 value:
-                  email: example.user.1@example.com
+                  address: example.user.1@example.com
                   note: Updated recipients
       responses:
         '200':
@@ -3385,7 +4534,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SlackChannel"
+              "$ref": "#/components/schemas/SlackChannelPostRequest"
             examples:
               example:
                 summary: Slack Channel
@@ -3516,7 +4665,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/SlackChannel"
+              "$ref": "#/components/schemas/SlackChannelPutRequest"
             examples:
               example:
                 summary: Slack channel
@@ -3680,14 +4829,16 @@ paths:
           type: integer
         description: The page number of the tunings list
         example: 1
+      - "$ref": "#/components/parameters/pageSize"
+      - "$ref": "#/components/parameters/pageNum"
+      - "$ref": "#/components/parameters/watch"
       - in: query
-        name: pageSize
+        name: modified
         required: false
         schema:
-          type: integer
-        description: The page size of the tunings list
-        example: 10
-      - "$ref": "#/components/parameters/watch"
+          type: boolean
+        description: The flag to filter the modified tunings
+        example: true
       responses:
         '200':
           description: Retrieve the list of tunings from a host or data center successfully
@@ -3712,6 +4863,9 @@ paths:
                         limitation:
                           type: bool
                           default: false
+                        status:
+                          updatedAt: '2025-03-12T19:22:00+08:00'
+                          isUpdating: true
                       - name: cubesys.provider.extra
                         value: ''
                         hosts:
@@ -3723,6 +4877,9 @@ paths:
                         limitation:
                           type: string
                           default: ''
+                          regex: ''
+                        status:
+                          isUpdating: false
                       - name: barbican.debug.enabled
                         value: false
                         hosts:
@@ -3733,6 +4890,8 @@ paths:
                         limitation:
                           type: bool
                           default: false
+                        status:
+                          isUpdating: false
                       - name: cinder.backup.endpoint
                         value: ''
                         hosts:
@@ -3743,6 +4902,9 @@ paths:
                         limitation:
                           type: string
                           default: ''
+                          regex: ''
+                        status:
+                          isUpdating: false
                       - name: influxdb.curator.rp
                         value: 7
                         hosts:
@@ -3756,6 +4918,8 @@ paths:
                           default: 7
                           min: 0
                           max: 365
+                        status:
+                          isUpdating: false
                       - name: influxdb.curator.rp
                         value: 23
                         hosts:
@@ -3768,10 +4932,13 @@ paths:
                           default: 7
                           min: 0
                           max: 365
+                        status:
+                          isUpdating: false
                       page:
                         total: 15
                         number: 1
                         size: 5
+                        'totalItemCount:': 75
                     msg: fetch tuning list successfully
                     status: ok
         '401':
@@ -4657,11 +5824,8 @@ paths:
                 summary: Tuning update request
                 value:
                   value: true
-                  enabled: true
-                  roles:
-                  - name: control-converged
-                    hosts:
-                    - name: example-node-0
+                  hosts:
+                  - example-node-0
       responses:
         '202':
           description: Update the tuning successfully
@@ -4724,7 +5888,99 @@ paths:
                   status:
                     type: string
                     example: internal server error
-    put:
+  "/api/v1/datacenters/{dataCenter}/tunings/parameters/{parameterName}/enable":
+    patch:
+      operationId: enableOrDisableTuning
+      tags:
+      - Tunings
+      summary: Enable or disable a specific tuning parameter
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - in: path
+        name: parameterName
+        required: true
+        schema:
+          type: string
+        description: The name of the parameter to update. use GET /api/v1/datacenters/{dataCenter}/tunings/specs
+          to get the list of parameters
+        example: barbican.debug.enabled
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/EnableOrDisableTuningRequest"
+            examples:
+              example:
+                summary: Tuning update request
+                value:
+                  enable: true
+                  hosts:
+                  - example-node-0
+      responses:
+        '202':
+          description: Enable or disable the tuning successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UpdateTuningResponse"
+              examples:
+                example:
+                  summary: Tuning update request received
+                  value:
+                    code: 202
+                    msg: tuning update request received
+                    status: ok
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 400
+                  msg:
+                    type: string
+                    example: invalid parameter name
+                  status:
+                    type: string
+                    example: bad request
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to request tuning update: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/tunings/parameters/{parameterName}/reset":
+    post:
       operationId: resetTuning
       tags:
       - Tunings
@@ -4749,10 +6005,8 @@ paths:
               example:
                 summary: Tuning reset request
                 value:
-                  roles:
-                  - name: control-converged
-                    hosts:
-                    - name: example-node-0
+                  hosts:
+                  - example-node-0
       responses:
         '202':
           description: Reset the tuning successfully
@@ -4815,6 +6069,611 @@ paths:
                   status:
                     type: string
                     example: internal server error
+  "/api/v1/datacenters/{dataCenter}/triggers":
+    get:
+      operationId: getTriggers
+      tags:
+      - Triggers
+      summary: Retrieve all triggers
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      responses:
+        '200':
+          description: Retrieve triggers successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GetTriggersResponse"
+              examples:
+                example:
+                  summary: Triggers list
+                  value:
+                    code: 200
+                    data:
+                    - name: Administrative Level Notification
+                      description: Configure how you are going to be notified for
+                        system events and host alerts, including levels 'warning',
+                        'error', and 'critical'.
+                      attributes:
+                      - name: severity
+                        type: string
+                        value: W
+                        enabled: false
+                      - name: severity
+                        type: string
+                        value: E
+                        enabled: false
+                      - name: severity
+                        type: string
+                        value: C
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: DEV
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: CPU
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: DSK
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: MEM
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: NET
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: SRV
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: VRT
+                        enabled: false
+                      response:
+                        types:
+                        - email
+                        - slack
+                        slacks:
+                        - name: amqp-alert-p1
+                          url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
+                          description: example slack channel 1
+                        - name: "#test-cos-300-notification"
+                          url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
+                          description: example slack channel 2
+                        emails:
+                        - address: example.user@example.com
+                          note: example email recipient
+                      enabled: false
+                    - name: Instance Level Notification
+                      description: Configure how you are going to be notified for
+                        instance alerts, including levels 'warning', and 'critical'.
+                      attributes:
+                      - name: severity
+                        type: string
+                        value: W
+                        enabled: false
+                      - name: severity
+                        type: string
+                        value: E
+                        enabled: false
+                      - name: severity
+                        type: string
+                        value: C
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: DEV
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: CPU
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: DSK
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: MEM
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: NET
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: SRV
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: VRT
+                        enabled: false
+                      response:
+                        types:
+                        - email
+                        - slack
+                        slacks:
+                        - name: amqp-alert-p1
+                          url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
+                          description: example slack channel 1
+                        - name: "#test-cos-300-notification"
+                          url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
+                          description: example slack channel 2
+                        emails:
+                        - address: example.user@example.com
+                          note: example email recipient
+                      enabled: false
+                    msg: fetch triggers successfully
+                    status: ok
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to list triggers: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/triggers/{triggerName}":
+    get:
+      operationId: getTrigger
+      tags:
+      - Triggers
+      summary: Retrieve a specific trigger
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - in: path
+        name: triggerName
+        required: true
+        schema:
+          type: string
+        description: The name of the trigger to operate
+        example: Administrative Level Notification
+      responses:
+        '200':
+          description: Retrieve trigger successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GetTriggerResponse"
+              examples:
+                example:
+                  summary: Get a specific trigger
+                  value:
+                    code: 200
+                    data:
+                      name: Administrative Level Notification
+                      description: Configure how you are going to be notified for
+                        system events and host alerts, including levels 'warning',
+                        'error', and 'critical'.
+                      attributes:
+                      - name: severity
+                        type: string
+                        value: W
+                        enabled: false
+                      - name: severity
+                        type: string
+                        value: E
+                        enabled: false
+                      - name: severity
+                        type: string
+                        value: C
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: DEV
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: CPU
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: DSK
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: MEM
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: NET
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: SRV
+                        enabled: false
+                      - name: category
+                        type: string
+                        value: VRT
+                        enabled: false
+                      response:
+                        types:
+                        - email
+                        - slack
+                        slacks:
+                        - name: amqp-alert-p1
+                          url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
+                          description: example slack channel 1
+                        - name: "#test-cos-300-notification"
+                          url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
+                          description: example slack channel 2
+                        emails:
+                        - address: example.user@example.com
+                          note: example email recipient
+                      enabled: false
+                    msg: fetch trigger successfully
+                    status: ok
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to list triggers: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+    patch:
+      operationId: updateTrigger
+      tags:
+      - Triggers
+      summary: Update a specific trigger
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - in: path
+        name: triggerName
+        required: true
+        schema:
+          type: string
+        description: The name of the trigger to operate
+        example: Administrative Level Notification
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UpdateTriggerRequest"
+            examples:
+              example:
+                summary: Trigger update request
+                value:
+                  attributes:
+                  - name: severity
+                    type: string
+                    value: W
+                    enabled: true
+                  - name: severity
+                    type: string
+                    value: E
+                    enabled: true
+                  - name: severity
+                    type: string
+                    value: C
+                    enabled: true
+                  - name: category
+                    type: string
+                    value: DEV
+                    enabled: false
+                  - name: category
+                    type: string
+                    value: CPU
+                    enabled: false
+                  - name: category
+                    type: string
+                    value: DSK
+                    enabled: false
+                  - name: category
+                    type: string
+                    value: MEM
+                    enabled: false
+                  - name: category
+                    type: string
+                    value: NET
+                    enabled: false
+                  - name: category
+                    type: string
+                    value: SRV
+                    enabled: false
+                  - name: category
+                    type: string
+                    value: VRT
+                    enabled: false
+                  response:
+                    slacks:
+                    - url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
+                    emails:
+                    - address: example.user@example.com
+                  enabled: false
+      responses:
+        '202':
+          description: Update trigger request received
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UpdateTriggerResponse"
+              examples:
+                example:
+                  summary: Trigger update request received
+                  value:
+                    code: 202
+                    msg: trigger update request received
+                    status: ok
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 400
+                  msg:
+                    type: string
+                    example: invalid trigger name
+                  status:
+                    type: string
+                    example: bad request
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to request trigger update: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/supportFiles":
+    get:
+      operationId: getSupportFiles
+      tags:
+      - Support Files
+      summary: Retrieve all support files
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/watch"
+      - "$ref": "#/components/parameters/pageSize"
+      - "$ref": "#/components/parameters/pageNum"
+      - "$ref": "#/components/parameters/keyword"
+      responses:
+        '200':
+          description: Retrieve support files successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GetSupportFilesResponse"
+              examples:
+                example:
+                  summary: Support file set list
+                  value:
+                    code: 200
+                    data:
+                      supportFileSet:
+                      - name: CUBE COS 3.0.0 Support File Set 2025-03-18T03:37:19+00:00
+                        description: example-description
+                        files:
+                        - name: CUBE_3.0.0_20250318-033723_example-node-0.support
+                          group: Cube Appliance 3.0.0 Support File Set 2025-03-18T03:37:19+00:00
+                          description: example-description
+                          source:
+                            role: control-converged
+                            host: example-node-0
+                          sizeMiB: 98.3954
+                          url: http://example-data-center/supportfiles/CUBE_3.0.0_20250318-215742_example-node-0.support?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Checksum-Mode=ENABLED&X-Amz-Credential=admin%2F20250318%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20250318T140312Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=ae8c2a39d348709b51d6c0d4b731716f1dc33c172ba43c2919357106cbb15389
+                          status:
+                            isCreating: false
+                        - name: CUBE_3.0.0_20250318-033723_example-node-1.support
+                          group: Cube Appliance 3.0.0 Support File Set 2025-03-18T03:37:19+00:00
+                          description: example-description
+                          source:
+                            role: control-converged
+                            host: example-node-1
+                          sizeMiB: 98.3954
+                          url: http://example-data-center/supportfiles/CUBE_3.0.0_20250318-215742_example-node-1.support?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Checksum-Mode=ENABLED&X-Amz-Credential=admin%2F20250318%2Fauto%2Fs3%2Faws4_request&X-Amz-Date=20250318T140312Z&X-Amz-Expires=604800&X-Amz-SignedHeaders=host&x-id=GetObject&X-Amz-Signature=ae8c2a39d348709b51d6c0d4b731716f1dc33c172ba43c2919357106cbb15389
+                          status:
+                            isCreating: false
+                        sizeMiB: 196.7908
+                        status:
+                          current: completed
+                          createdAt: '2025-03-18T03:37:19+00:00'
+                          isCreating: false
+                      page:
+                        total: 1
+                        number: 1
+                        size: 1
+                        totalItemCount: 1
+                    msg: retrieved support files successfully
+                    status: ok
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to list support files: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+    post:
+      operationId: createSupportFiles
+      tags:
+      - Support Files
+      summary: Create one or more support files
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/CreateSupportFilesRequest"
+            examples:
+              example:
+                summary: Support file creation request
+                value:
+                  description: example-description
+                  hosts:
+                  - example-node-0
+      responses:
+        '202':
+          description: Support file creation request received
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/CreateSupportFilesResponse"
+              examples:
+                example:
+                  summary: Support file creation response
+                  value:
+                    code: 202
+                    msg: support file creation request received
+                    status: ok
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 400
+                  msg:
+                    type: string
+                    example: invalid host found
+                  status:
+                    type: string
+                    example: bad request
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to request support file creation: internal server
+                      error'
+                  status:
+                    type: string
+                    example: internal server error
 components:
   parameters:
     dataCenter:
@@ -4834,6 +6693,30 @@ components:
       description: The toggle to enable http chunked transfer for continuous server
         push.
       example: true
+    pageSize:
+      in: query
+      name: pageSize
+      required: false
+      schema:
+        type: integer
+      description: The number of items per page (default is unlimit).
+      example: 10
+    pageNum:
+      in: query
+      name: pageNum
+      required: false
+      schema:
+        type: integer
+      description: The page number to retrieve
+      example: 1
+    keyword:
+      in: query
+      name: keyword
+      required: false
+      schema:
+        type: string
+      description: The keyword to search, can be any string
+      example: example-keyword
   schemas:
     GetMeResponse:
       type: object
@@ -5059,21 +6942,7 @@ components:
                     type: string
                     example: '2025-01-01T01:00:00+00:00'
             page:
-              type: object
-              required:
-              - total
-              - number
-              - size
-              properties:
-                total:
-                  type: integer
-                  example: 10
-                number:
-                  type: integer
-                  example: 1
-                size:
-                  type: integer
-                  example: 1
+              "$ref": "#/components/schemas/Page"
         msg:
           type: string
           example: fetch events successfully
@@ -5646,18 +7515,7 @@ components:
                       days:
                         type: integer
             page:
-              type: object
-              required:
-              - total
-              - number
-              - size
-              properties:
-                total:
-                  type: integer
-                number:
-                  type: integer
-                size:
-                  type: integer
+              "$ref": "#/components/schemas/Page"
         msg:
           type: string
         status:
@@ -5784,17 +7642,17 @@ components:
                   - moderator
                   properties:
                     controlConverged:
-                      "$ref": "#/components/schemas/roleUsage"
+                      "$ref": "#/components/schemas/RoleUsage"
                     control:
-                      "$ref": "#/components/schemas/roleUsage"
+                      "$ref": "#/components/schemas/RoleUsage"
                     compute:
-                      "$ref": "#/components/schemas/roleUsage"
+                      "$ref": "#/components/schemas/RoleUsage"
                     storage:
-                      "$ref": "#/components/schemas/roleUsage"
+                      "$ref": "#/components/schemas/RoleUsage"
                     edgeCore:
-                      "$ref": "#/components/schemas/roleUsage"
+                      "$ref": "#/components/schemas/RoleUsage"
                     moderator:
-                      "$ref": "#/components/schemas/roleUsage"
+                      "$ref": "#/components/schemas/RoleUsage"
                 usages:
                   type: array
                   items:
@@ -6015,7 +7873,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/metricRank"
+          "$ref": "#/components/schemas/MetricRank"
         msg:
           type: string
           example: fetch metrics successfully
@@ -6068,7 +7926,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/metricRank"
+          "$ref": "#/components/schemas/MetricRank"
         msg:
           type: string
           example: fetch metrics successfully
@@ -6086,7 +7944,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/metricRank"
+          "$ref": "#/components/schemas/MetricRank"
         msg:
           type: string
           example: fetch metrics successfully
@@ -6104,7 +7962,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/diskReadWriteHistory"
+          "$ref": "#/components/schemas/DiskReadWriteHistory"
         msg:
           type: string
         status:
@@ -6120,7 +7978,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/diskReadWriteHistory"
+          "$ref": "#/components/schemas/DiskReadWriteHistory"
         msg:
           type: string
         status:
@@ -6136,7 +7994,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/diskReadWriteHistory"
+          "$ref": "#/components/schemas/DiskReadWriteHistory"
         msg:
           type: string
         status:
@@ -6152,7 +8010,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/metricRank"
+          "$ref": "#/components/schemas/MetricRank"
         msg:
           type: string
           example: fetch metrics successfully
@@ -6170,7 +8028,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/metricRank"
+          "$ref": "#/components/schemas/MetricRank"
         msg:
           type: string
           example: fetch metrics successfully
@@ -6188,7 +8046,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/metricRank"
+          "$ref": "#/components/schemas/MetricRank"
         msg:
           type: string
           example: fetch metrics successfully
@@ -6241,7 +8099,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/metricRank"
+          "$ref": "#/components/schemas/MetricRank"
         msg:
           type: string
           example: fetch metrics successfully
@@ -6259,7 +8117,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/metricRank"
+          "$ref": "#/components/schemas/MetricRank"
         msg:
           type: string
           example: fetch metrics successfully
@@ -6277,7 +8135,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/metricRank"
+          "$ref": "#/components/schemas/MetricRank"
         msg:
           type: string
           example: fetch metrics successfully
@@ -6295,7 +8153,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/metricRank"
+          "$ref": "#/components/schemas/MetricRank"
         msg:
           type: string
           example: fetch metrics successfully
@@ -6313,7 +8171,7 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/metricRank"
+          "$ref": "#/components/schemas/MetricRank"
         msg:
           type: string
           example: fetch metrics successfully
@@ -6340,172 +8198,28 @@ components:
             nodes:
               type: array
               items:
-                type: object
-                required:
-                - id
-                - hostname
-                - role
-                - address
-                - managementIP
-                - license
-                - status
-                - vcpu
-                - memory
-                - storage
-                - uptimeSeconds
-                - labels
-                properties:
-                  id:
-                    type: string
-                  hostname:
-                    type: string
-                  role:
-                    type: string
-                  address:
-                    type: string
-                  managementIP:
-                    type: string
-                  license:
-                    type: object
-                    required:
-                    - status
-                    - hostname
-                    - serial
-                    - product
-                    - issue
-                    - serviceLevelAgreement
-                    - expiry
-                    properties:
-                      status:
-                        type: string
-                      hostname:
-                        type: string
-                      serial:
-                        type: string
-                      product:
-                        type: object
-                        required:
-                        - name
-                        - features
-                        properties:
-                          name:
-                            type: string
-                          features:
-                            type: object
-                            required:
-                            - name
-                            properties:
-                              name:
-                                type: string
-                      issue:
-                        type: object
-                        required:
-                        - by
-                        - to
-                        - hardware
-                        - date
-                        properties:
-                          by:
-                            type: string
-                          to:
-                            type: string
-                          hardware:
-                            type: string
-                          date:
-                            type: string
-                      serviceLevelAgreement:
-                        type: object
-                        required:
-                        - uptime
-                        - period
-                        - meanTimeBetweenFailure
-                        - meanTimeToRepair
-                        - expire
-                        properties:
-                          uptime:
-                            type: number
-                          period:
-                            type: string
-                          meanTimeBetweenFailure:
-                            type: string
-                          meanTimeToRepair:
-                            type: string
-                      expiry:
-                        type: object
-                        required:
-                        - date
-                        - days
-                        properties:
-                          date:
-                            type: string
-                          days:
-                            type: integer
-                  status:
-                    type: string
-                  vcpu:
-                    type: object
-                    required:
-                    - totalCores
-                    - usedCores
-                    - freeCores
-                    properties:
-                      totalCores:
-                        type: integer
-                      usedCores:
-                        type: integer
-                      freeCores:
-                        type: integer
-                  memory:
-                    type: object
-                    required:
-                    - totalMiB
-                    - usedMiB
-                    - freeMiB
-                    properties:
-                      totalMiB:
-                        type: integer
-                      usedMiB:
-                        type: integer
-                      freeMiB:
-                        type: integer
-                  storage:
-                    type: object
-                    required:
-                    - totalMiB
-                    - usedMiB
-                    - freeMiB
-                    properties:
-                      totalMiB:
-                        type: integer
-                      usedMiB:
-                        type: integer
-                      freeMiB:
-                        type: integer
-                  uptimeSeconds:
-                    type: number
-                  labels:
-                    type: object
-                    required:
-                    - isGpuEnabled
-                    properties:
-                      isGpuEnabled:
-                        type: string
+                "$ref": "#/components/schemas/Node"
             page:
-              type: object
-              required:
-              - total
-              - number
-              - size
-              properties:
-                total:
-                  type: integer
-                  example: 10
-                number:
-                  type: integer
-                  example: 1
-                size:
-                  type: integer
-                  example: 1
+              "$ref": "#/components/schemas/Page"
+        msg:
+          type: string
+          example: fetch nodes successfully
+        status:
+          type: string
+          example: ok
+    GetNodeResponse:
+      type: object
+      required:
+      - code
+      - data
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 200
+        data:
+          "$ref": "#/components/schemas/Node"
         msg:
           type: string
           example: fetch nodes successfully
@@ -6561,6 +8275,33 @@ components:
           type: string
         status:
           type: string
+    GetSupportFilesResponse:
+      type: object
+      required:
+      - code
+      - data
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 200
+        data:
+          type: object
+          required:
+          - supportFileSet
+          - page
+          properties:
+            supportFileSet:
+              type: array
+              items:
+                "$ref": "#/components/schemas/SupportFileSet"
+            page:
+              "$ref": "#/components/schemas/Page"
+        msg:
+          type: string
+        status:
+          type: string
     TitlePrefix:
       type: object
       required:
@@ -6568,7 +8309,26 @@ components:
       properties:
         value:
           type: string
-    EmailSender:
+    EmailSenderResponse:
+      type: object
+      required:
+      - host
+      - port
+      - username
+      - email
+      - accessVerified
+      properties:
+        host:
+          type: string
+        port:
+          type: integer
+        username:
+          type: string
+        email:
+          type: string
+        accessVerified:
+          type: boolean
+    EmailSenderPostRequest:
       type: object
       required:
       - host
@@ -6576,7 +8336,6 @@ components:
       - username
       - password
       - email
-      - accessVerified
       properties:
         host:
           type: string
@@ -6588,8 +8347,19 @@ components:
           type: string
         email:
           type: string
-        accessVerified:
-          type: boolean
+    EmailSenderPutRequest:
+      type: object
+      properties:
+        host:
+          type: string
+        port:
+          type: integer
+        username:
+          type: string
+        password:
+          type: string
+        email:
+          type: string
     TryEmailSender:
       type: object
       required:
@@ -6597,25 +8367,61 @@ components:
       properties:
         email:
           type: string
-    EmailRecipient:
+    EmailRecipientResponse:
       type: object
       required:
-      - email
+      - address
       - note
-      - isTestable
       properties:
-        email:
+        address:
           type: string
         note:
           type: string
-        isTestable:
-          type: boolean
-    SlackChannel:
+    EmailRecipientPostRequest:
+      type: object
+      required:
+      - address
+      - note
+      properties:
+        address:
+          type: string
+        note:
+          type: string
+    EmailRecipientPutRequest:
+      type: object
+      properties:
+        address:
+          type: string
+        note:
+          type: string
+    SlackChannelGetResponse:
       type: object
       required:
       - name
       - url
       - description
+      properties:
+        name:
+          type: string
+        url:
+          type: string
+        description:
+          type: string
+    SlackChannelPostRequest:
+      type: object
+      required:
+      - name
+      - url
+      - description
+      properties:
+        name:
+          type: string
+        url:
+          type: string
+        description:
+          type: string
+    SlackChannelPutRequest:
+      type: object
       properties:
         name:
           type: string
@@ -6651,16 +8457,16 @@ components:
                 senders:
                   type: array
                   items:
-                    "$ref": "#/components/schemas/EmailSender"
+                    "$ref": "#/components/schemas/EmailSenderResponse"
                 recipients:
                   type: array
                   items:
-                    "$ref": "#/components/schemas/EmailRecipient"
+                    "$ref": "#/components/schemas/EmailRecipientResponse"
             slack:
               type: object
               properties:
                 channel:
-                  "$ref": "#/components/schemas/SlackChannel"
+                  "$ref": "#/components/schemas/SlackChannelPostRequest"
         msg:
           type: string
         status:
@@ -6730,7 +8536,7 @@ components:
             emailSenders:
               type: array
               items:
-                "$ref": "#/components/schemas/EmailSender"
+                "$ref": "#/components/schemas/EmailSenderResponse"
         msg:
           type: string
           example: email senders retrieved successfully
@@ -6798,7 +8604,7 @@ components:
         data:
           type: array
           items:
-            "$ref": "#/components/schemas/EmailRecipient"
+            "$ref": "#/components/schemas/EmailRecipientResponse"
         msg:
           type: string
         status:
@@ -6881,7 +8687,7 @@ components:
         data:
           type: array
           items:
-            "$ref": "#/components/schemas/SlackChannel"
+            "$ref": "#/components/schemas/SlackChannelGetResponse"
         msg:
           type: string
           example: slack channels retrieved successfully
@@ -6938,61 +8744,86 @@ components:
           example: ok
     ListTuningResponse:
       type: object
+      required:
+      - code
+      - data
+      - msg
+      - status
       properties:
         code:
           type: integer
           example: 200
         data:
-          type: array
-          items:
-            type: object
-            required:
-            - name
-            - value
-            - hosts
-            - description
-            - enabled
-            - isModified
-            - limitation
-            properties:
-              name:
-                type: string
-              value:
-                type: string
-              hosts:
-                type: array
-                items:
-                  type: string
-              description:
-                type: string
-              enabled:
-                type: boolean
-              isModified:
-                type: boolean
-              limitation:
+          type: object
+          required:
+          - tunings
+          - page
+          properties:
+            tunings:
+              type: array
+              items:
                 type: object
                 required:
-                - type
-                - default
-                - min
-                - max
+                - name
+                - value
+                - hosts
+                - description
+                - enabled
+                - isModified
+                - limitation
+                - status
                 properties:
-                  type:
+                  name:
                     type: string
-                  default:
-                    oneOf:
-                    - type: string
-                    - type: integer
-                    - type: number
-                    - type: boolean
-                  min:
-                    oneOf:
-                    - type: integer
-                    - type: number
-                  max:
-                    oneOf:
-                    - type: integer
-                    - type: number
+                  value:
+                    type: string
+                  hosts:
+                    type: array
+                    items:
+                      type: string
+                  description:
+                    type: string
+                  enabled:
+                    type: boolean
+                  isModified:
+                    type: boolean
+                  limitation:
+                    type: object
+                    required:
+                    - type
+                    - default
+                    - min
+                    - max
+                    properties:
+                      type:
+                        type: string
+                      default:
+                        oneOf:
+                        - type: string
+                        - type: integer
+                        - type: number
+                        - type: boolean
+                      min:
+                        oneOf:
+                        - type: integer
+                        - type: number
+                      max:
+                        oneOf:
+                        - type: integer
+                        - type: number
+                      regex:
+                        type: string
+                  status:
+                    type: object
+                    required:
+                    - isUpdating
+                    properties:
+                      updatedAt:
+                        type: string
+                      isUpdating:
+                        type: boolean
+            page:
+              "$ref": "#/components/schemas/Page"
         msg:
           type: string
           example: tuning list retrieved successfully
@@ -7001,6 +8832,11 @@ components:
           example: ok
     ListTuningSpecResponse:
       type: object
+      required:
+      - code
+      - data
+      - msg
+      - status
       properties:
         code:
           type: integer
@@ -7042,10 +8878,15 @@ components:
                     oneOf:
                     - type: integer
                     - type: number
+                  regex:
+                    type: string
               roles:
                 type: array
                 items:
                   type: object
+                  required:
+                  - name
+                  - hosts
                   properties:
                     name:
                       type: string
@@ -7069,57 +8910,38 @@ components:
       type: object
       required:
       - value
-      - enabled
-      - roles
+      - hosts
       properties:
         value:
-          type: boolean
-        enabled:
-          type: boolean
-        roles:
+          oneOf:
+          - type: string
+          - type: integer
+          - type: boolean
+        hosts:
           type: array
           items:
-            type: object
-            required:
-            - name
-            - hosts
-            properties:
-              name:
-                type: string
-              hosts:
-                type: array
-                items:
-                  type: object
-                  required:
-                  - name
-                  - ip
-                  properties:
-                    name:
-                      type: string
+            type: string
+    EnableOrDisableTuningRequest:
+      type: object
+      required:
+      - enable
+      - hosts
+      properties:
+        enable:
+          type: boolean
+        hosts:
+          type: array
+          items:
+            type: string
     ResetTuningRequest:
       type: object
       required:
-      - roles
+      - hosts
       properties:
-        roles:
+        hosts:
           type: array
           items:
-            type: object
-            required:
-            - name
-            - hosts
-            properties:
-              name:
-                type: string
-              hosts:
-                type: array
-                items:
-                  type: object
-                  required:
-                  - name
-                  properties:
-                    name:
-                      type: string
+            type: string
     UpdateTuningResponse:
       type: object
       required:
@@ -7146,7 +8968,270 @@ components:
           type: string
         status:
           type: string
-    metricRank:
+    GetTriggersResponse:
+      type: object
+      required:
+      - code
+      - data
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 200
+        data:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - description
+            - attributes
+            - response
+            - enabled
+            properties:
+              name:
+                type: string
+              description:
+                type: string
+              attributes:
+                type: object
+                required:
+                - name
+                - type
+                - value
+                - enabled
+                properties:
+                  name:
+                    type: string
+                  type:
+                    type: string
+                  value:
+                    type: string
+                  enabled:
+                    type: boolean
+              response:
+                type: object
+                required:
+                - types
+                - slacks
+                - emails
+                properties:
+                  types:
+                    type: array
+                    items:
+                      type: string
+                  slacks:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - name
+                      - url
+                      - description
+                      properties:
+                        name:
+                          type: string
+                        url:
+                          type: string
+                        description:
+                          type: string
+                  emails:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - address
+                      - note
+                      properties:
+                        address:
+                          type: string
+                        note:
+                          type: string
+              enabled:
+                type: boolean
+        msg:
+          type: string
+          example: triggers retrieved successfully
+        status:
+          type: string
+          example: ok
+    GetTriggerResponse:
+      type: object
+      required:
+      - code
+      - data
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 200
+        data:
+          type: object
+          required:
+          - name
+          - description
+          - attributes
+          - response
+          - enabled
+          properties:
+            name:
+              type: string
+            description:
+              type: string
+            attributes:
+              type: object
+              required:
+              - name
+              - type
+              - value
+              - enabled
+              properties:
+                name:
+                  type: string
+                type:
+                  type: string
+                value:
+                  type: string
+                enabled:
+                  type: boolean
+            response:
+              type: object
+              required:
+              - types
+              - slacks
+              - emails
+              properties:
+                types:
+                  type: array
+                  items:
+                    type: string
+                slacks:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - name
+                    - url
+                    - description
+                    properties:
+                      name:
+                        type: string
+                      url:
+                        type: string
+                      description:
+                        type: string
+                emails:
+                  type: array
+                  items:
+                    type: object
+                    required:
+                    - email
+                    - note
+                    properties:
+                      email:
+                        type: string
+                      note:
+                        type: string
+            enabled:
+              type: boolean
+        msg:
+          type: string
+          example: triggers retrieved successfully
+        status:
+          type: string
+          example: ok
+    UpdateTriggerRequest:
+      type: object
+      required:
+      - attributes
+      - response
+      - enabled
+      properties:
+        attributes:
+          type: array
+          items:
+            type: object
+            required:
+            - name
+            - type
+            - value
+            - enabled
+            properties:
+              name:
+                type: string
+              type:
+                type: string
+              value:
+                type: string
+              enabled:
+                type: boolean
+        response:
+          type: object
+          required:
+          - slacks
+          - emails
+          properties:
+            slacks:
+              type: array
+              items:
+                type: object
+                required:
+                - url
+                properties:
+                  url:
+                    type: string
+            emails:
+              type: array
+              items:
+                type: object
+                required:
+                - address
+                properties:
+                  address:
+                    type: string
+        enabled:
+          type: boolean
+    UpdateTriggerResponse:
+      type: object
+      required:
+      - code
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+        msg:
+          type: string
+        status:
+          type: string
+    CreateSupportFilesRequest:
+      type: object
+      required:
+      - description
+      - hosts
+      properties:
+        description:
+          type: string
+        hosts:
+          type: array
+          items:
+            type: string
+    CreateSupportFilesResponse:
+      type: object
+      required:
+      - code
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+        msg:
+          type: string
+        status:
+          type: string
+    MetricRank:
       type: object
       required:
       - unit
@@ -7185,7 +9270,7 @@ components:
                       format: date-time
                     value:
                       type: number
-    diskReadWriteHistory:
+    DiskReadWriteHistory:
       type: object
       required:
       - unit
@@ -7220,7 +9305,7 @@ components:
                 format: date-time
               value:
                 type: number
-    roleUsage:
+    RoleUsage:
       type: object
       required:
       - count
@@ -7267,3 +9352,324 @@ components:
               type: number
             freePercent:
               type: number
+    Page:
+      type: object
+      required:
+      - total
+      - number
+      - size
+      - totalItemCount
+      properties:
+        total:
+          type: integer
+          example: 10
+        number:
+          type: integer
+          example: 1
+        size:
+          type: integer
+          example: 1
+        totalItemCount:
+          type: integer
+          example: 1
+    Node:
+      type: object
+      required:
+      - id
+      - dataCenter
+      - hostname
+      - role
+      - protocol
+      - address
+      - ip
+      - managementIP
+      - license
+      - status
+      - cpuSpec
+      - networkInterfaces
+      - blockDevices
+      - vcpu
+      - memory
+      - storage
+      - uptimeSeconds
+      - labels
+      properties:
+        id:
+          type: string
+        dataCenter:
+          type: string
+        hostname:
+          type: string
+        role:
+          type: string
+        protocol:
+          type: string
+        address:
+          type: string
+        ip:
+          type: string
+        managementIP:
+          type: string
+        license:
+          type: object
+          required:
+          - type
+          - hostname
+          - serial
+          - product
+          - issue
+          - quantity
+          - serviceLevelAgreement
+          - expiry
+          properties:
+            type:
+              type: string
+            hostname:
+              type: string
+            serial:
+              type: string
+            product:
+              type: object
+              required:
+              - name
+              - features
+              properties:
+                name:
+                  type: string
+                features:
+                  type: object
+            issue:
+              type: object
+              required:
+              - by
+              - to
+              - hardware
+              - date
+              properties:
+                by:
+                  type: string
+                to:
+                  type: string
+                hardware:
+                  type: string
+                date:
+                  type: string
+                  format: date-time
+            quantity:
+              type: object
+              required:
+              - type
+              - vcpu
+              properties:
+                type:
+                  type: string
+                vcpu:
+                  type: integer
+            serviceLevelAgreement:
+              type: object
+              required:
+              - uptime
+              - period
+              - meanTimeBetweenFailure
+              - meanTimeToRe
+              properties:
+                uptime:
+                  type: integer
+                period:
+                  type: string
+                meanTimeBetweenFailure:
+                  type: string
+                meanTimeToRecovery:
+                  type: string
+            expiry:
+              type: object
+              required:
+              - date
+              - days
+              properties:
+                date:
+                  type: string
+                  format: date-time
+                days:
+                  type: integer
+        status:
+          type: string
+        cpuSpec:
+          type: string
+        networkInterfaces:
+          type: array
+          items:
+            type: object
+            required:
+            - label
+            - busIdSlaves
+            - driver
+            - state
+            - speed
+            properties:
+              label:
+                type: string
+              busIdSlaves:
+                type: string
+              driver:
+                type: string
+              state:
+                type: string
+              speed:
+                type: string
+        blockDevices:
+          type: array
+          items:
+            type: object
+            required:
+            - device
+            - type
+            - sizeMiB
+            - status
+            properties:
+              device:
+                type: string
+              type:
+                type: string
+              sizeMiB:
+                type: number
+              status:
+                type: string
+        vcpu:
+          type: object
+          required:
+          - totalCores
+          - usedCores
+          - usedPercent
+          - freeCores
+          - freePercent
+          properties:
+            totalCores:
+              type: integer
+            usedCores:
+              type: integer
+            usedPercent:
+              type: number
+            freeCores:
+              type: integer
+            freePercent:
+              type: number
+        memory:
+          type: object
+          required:
+          - totalMiB
+          - usedMiB
+          - usedPercent
+          - freeMiB
+          - freePercent
+          properties:
+            totalMiB:
+              type: number
+            usedMiB:
+              type: number
+            usedPercent:
+              type: number
+            freeMiB:
+              type: number
+            freePercent:
+              type: number
+        storage:
+          type: object
+          required:
+          - totalMiB
+          - usedMiB
+          - usedPercent
+          - freeMiB
+          - freePercent
+          properties:
+            totalMiB:
+              type: number
+            usedMiB:
+              type: number
+            usedPercent:
+              type: number
+            freeMiB:
+              type: number
+            freePercent:
+              type: number
+        uptimeSeconds:
+          type: number
+        labels:
+          type: object
+    SupportFileSet:
+      type: object
+      required:
+      - name
+      - description
+      - files
+      - sizeMiB
+      - status
+      properties:
+        name:
+          type: string
+        description:
+          type: string
+        files:
+          type: array
+          items:
+            type: object
+            "$ref": "#/components/schemas/SupportFile"
+        sizeMiB:
+          type: number
+        status:
+          type: object
+          required:
+          - current
+          - createdAt
+          - isCreating
+          properties:
+            current:
+              type: string
+            createdAt:
+              type: string
+            isCreating:
+              type: boolean
+    SupportFile:
+      type: object
+      required:
+      - name
+      - group
+      - description
+      - source
+      - url
+      - sizeMiB
+      - status
+      properties:
+        name:
+          type: string
+        sizeMiB:
+          type: number
+        group:
+          type: string
+        description:
+          type: string
+        source:
+          type: object
+          required:
+          - role
+          - host
+          properties:
+            role:
+              type: string
+            host:
+              type: string
+        url:
+          type: string
+        status:
+          type: object
+          required:
+          - current
+          - createdAt
+          - isCreating
+          properties:
+            current:
+              type: string
+            createdAt:
+              type: string
+            isCreating:
+              type: boolean

--- a/docs.yaml
+++ b/docs.yaml
@@ -2134,7 +2134,7 @@ paths:
         description: The end time of the event to query, the value should be in RFC3339
           format (default is now).
         example: '2025-01-01T01:00:00+00:00'
-      - $ref: "#/components/parameters/watch"
+      - "$ref": "#/components/parameters/watch"
       responses:
         '200':
           description: Retrieve the various metrics with different view from hosts
@@ -4822,13 +4822,6 @@ paths:
           type: string
         description: The keyword to search the tunings
         example: can be any string
-      - in: query
-        name: pageNum
-        required: false
-        schema:
-          type: integer
-        description: The page number of the tunings list
-        example: 1
       - "$ref": "#/components/parameters/pageSize"
       - "$ref": "#/components/parameters/pageNum"
       - "$ref": "#/components/parameters/watch"
@@ -6671,6 +6664,314 @@ paths:
                     type: string
                     example: 'failed to request support file creation: internal server
                       error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/grafana/hosts/{hostname}":
+    get:
+      operationId: fowardToGrafanaHosts
+      tags:
+      - Grafana
+      summary: Forward to Grafana hosts dashboard
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - in: path
+        name: hostname
+        required: true
+        schema:
+          type: string
+        description: The hostname of the host to operate
+        example: example-node-0
+      responses:
+        '302':
+          description: Forward to Grafana hosts dashboard
+          headers:
+            Location:
+              schema:
+                type: string
+                example: http://example-data-center/grafana/d/i-R2q81iz/host?refresh=5m&kiosk=tv&orgId=1&var-HOST=example-node-0
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to forward Grafana hosts dashboard: internal
+                      server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/grafana/instances/{instanceId}":
+    get:
+      operationId: fowardToGrafanaInstances
+      tags:
+      - Grafana
+      summary: Forward to Grafana instances dashboard
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - in: path
+        name: instanceId
+        required: true
+        schema:
+          type: string
+        description: The instance ID of the instance to operate
+        example: example-instance-id
+      responses:
+        '302':
+          description: Forward to Grafana instances dashboard
+          headers:
+            Location:
+              schema:
+                type: string
+                example: http://example-data-center/grafana/d/PVW6vU7Wz/instance?refresh=5m&kiosk=tv&orgId=1&var-UUID=example-instance-id
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to forward Grafana instances dashboard: internal
+                      server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/grafana/topHosts":
+    get:
+      operationId: fowardToGrafanaTopHosts
+      tags:
+      - Grafana
+      summary: Forward to Grafana top hosts dashboard
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      responses:
+        '302':
+          description: Forward to Grafana top hosts dashboard
+          headers:
+            Location:
+              schema:
+                type: string
+                example: http://example-data-center/grafana/d/M3ncw6lmk/top-hosts?refresh=5m&kiosk=tv&orgId=1
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to forward Grafana top hosts dashboard: internal
+                      server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/grafana/topInstances":
+    get:
+      operationId: fowardToGrafanaTopInstances
+      tags:
+      - Grafana
+      summary: Forward to Grafana top instances dashboard
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      responses:
+        '302':
+          description: Forward to Grafana top instances dashboard
+          headers:
+            Location:
+              schema:
+                type: string
+                example: http://example-data-center/grafana/d/qzfq087Wk/top-instances?refresh=5m&orgId=1&var-TID=&var-TOP=50&var-TENANT=admin
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to forward Grafana top instances dashboard: internal
+                      server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/grafana/networks":
+    get:
+      operationId: fowardToGrafanaNetworks
+      tags:
+      - Grafana
+      summary: Forward to Grafana networks dashboard
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      responses:
+        '302':
+          description: Forward to Grafana networks dashboard
+          headers:
+            Location:
+              schema:
+                type: string
+                example: http://example-data-center/grafana/d/Xx2kkftWk/network?orgId=1&refresh=5m
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to forward Grafana networks dashboard: internal
+                      server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/grafana/storages":
+    get:
+      operationId: fowardToGrafanaStorages
+      tags:
+      - Grafana
+      summary: Forward to Grafana storages dashboard
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      responses:
+        '302':
+          description: Forward to Grafana storages dashboard
+          headers:
+            Location:
+              schema:
+                type: string
+                example: http://example-data-center/grafana/d/QTc_sAxiw/storage?refresh=5m&kiosk=tv&orgId=1
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to forward Grafana storages dashboard: internal
+                      server error'
                   status:
                     type: string
                     example: internal server error


### PR DESCRIPTION
### What type of PR is this?

Feat and refactor

<br/>

### Which issue(s) this PR fixes?


- Trigger

  - https://github.com/bigstack-oss/cube-cos-api/issues/55

  - https://github.com/bigstack-oss/cube-cos-api/issues/56

  - https://github.com/bigstack-oss/cube-cos-api/issues/58


- Tuning

  - https://github.com/bigstack-oss/cube-cos-api/issues/115

  - https://github.com/bigstack-oss/cube-cos-api/issues/106

  - https://github.com/bigstack-oss/cube-cos-api/issues/107

  - https://github.com/bigstack-oss/cube-cos-api/issues/108


- Setting

  - https://github.com/bigstack-oss/cube-cos-api/issues/52


- Support file

  - https://github.com/bigstack-oss/cube-cos-api/issues/61
  
  - https://github.com/bigstack-oss/cube-cos-api/issues/62


- Node

  - https://github.com/bigstack-oss/cube-cos-api/issues/25

  - https://github.com/bigstack-oss/cube-cos-api/issues/64

  - https://github.com/bigstack-oss/cube-cos-api/issues/65



<br/>


### What this PR does?

- Tuning:

  - add a `PATCH` API to enable/disable tuning

  - add a `POST` API to reset the tuning

  - simply the `host schema` from the `PATCH` request

  - chore: add some missed query parameters back to listing API like `modified, isUpdating, and updatedAt`

- Setting:

  - chore: remove or polish some of minor fields like `isTestable` can be removed from email recipient list

  - don't bring back the `password` info in the email sender list

- Node:

  - add a `GET` API to fetch node details (haven't discussed with FE, it's a 1st iteration draft)

  - enrich the node info in the listing API

- Support file (haven't discussed with FE, it's a 1st iteration draft):

  - add a `GET` API to list the `support file set(group)`

  - add a `POST` api to create a support file on a node or multiple nodes 


- Trigger (haven't discussed with FE, it's a 1st iteration draft):

  - add a `GET` API to list the `default triggers`

  - add a `GET` API to fetch the trigger details

  - add a `PATCH` API to update a trigger


- Grafana (haven't discussed with FE, it's a 1st iteration draft):

  - add a `GET` API to forward the `top host` dashboard

  - add a `GET` API to forward the `top instance` dashboard

  - add a `GET` API to forward the `host details` dashboard

  - add a `GET` API to forward the `instance details` dashboard

  - add a `GET` API to forward the `network` dashboard

  - add a `GET` API to forward the `storage` dashboard


- Parameter:

  - converge `pageSize` and `pageNum` parameter to be an individual ref

  - add `totalItemCount` in the pagination info


<br/>


### Test results (optional)

Could be checked on CI result

