### PR TITLE
fix: get settings response schema slack channels

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -8819,7 +8819,9 @@ components:
               type: object
               properties:
                 channels:
-                  "$ref": "#/components/schemas/SlackChannelPostRequest"
+                  type: array
+                  items:
+                    "$ref": "#/components/schemas/SlackChannelPostRequest"
         msg:
           type: string
         status:


### PR DESCRIPTION
### What type of PR is this?

Fix

### Which issue(s) this PR fixes?

The `data.slack.channels` field of the getSettings API should be an array.

### What this PR does?

Fix issue.

### Test results (optional)

<img width="525" alt="{5FE41417-BA34-459C-AEF0-52EC3D716847}" src="https://github.com/user-attachments/assets/3640e2be-3532-407d-9129-1d2ac03a6eba" />

