### PR TITLE
Fix the incorrect 'isRepaired' schema to 'isRepairable' in the api doc

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -1136,7 +1136,7 @@ paths:
                     - category: cloud computing
                       service: compute
                       module: nova
-                      isRepaired: true
+                      isRepairable: true
                       history:
                       - time: '2025-02-15T08:44:36+00:00'
                         status: ng
@@ -1200,7 +1200,7 @@ paths:
                     - category: cloud computing
                       service: compute
                       module: cyborg
-                      isRepaired: true
+                      isRepairable: true
                       history:
                       - time: '2025-02-15T08:44:36+00:00'
                         status: ng
@@ -1446,7 +1446,7 @@ paths:
                       category: cloud computing
                       name: compute
                       module: nova
-                      isRepaired: true
+                      isRepairable: true
                       history:
                       - time: '2025-02-01T03:00:00+00:00'
                         status: ok
@@ -7708,7 +7708,7 @@ components:
             required:
             - category
             - service
-            - isRepaired
+            - isRepairable
             - history
             - module
             properties:
@@ -7716,7 +7716,7 @@ components:
                 type: string
               service:
                 type: string
-              isRepaired:
+              isRepairable:
                 type: boolean
               history:
                 type: array
@@ -7805,7 +7805,7 @@ components:
           - category
           - name
           - module
-          - isRepaired
+          - isRepairable
           - history
           properties:
             category:
@@ -7814,7 +7814,7 @@ components:
               type: string
             module:
               type: string
-            isRepaired:
+            isRepairable:
               type: boolean
             history:
               type: array


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cube-cos-api/pull/151

<br/>

### What this PR does?

- fix the incorrect 'isRepaired' schema to 'isRepairable' in the api doc

<br/>

### Test results (optional)

1). make sure the API doc has been updated accordingly

<img width="1430" alt="Screenshot 2025-03-23 at 2 59 44 PM" src="https://github.com/user-attachments/assets/cd7cfa04-82d2-4e7e-9144-7f2697637c85" />
<img width="1445" alt="Screenshot 2025-03-23 at 2 59 51 PM" src="https://github.com/user-attachments/assets/881125dd-c70d-40af-af1a-28bc1f271b3c" />

