### PR TITLE
Add a new field 'serial' and adjust the example of type and status for node's storage list

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -7357,6 +7357,64 @@ paths:
                   status:
                     type: string
                     example: internal server error
+  "/api/v1/datacenters/{dataCenter}/grafana/networkDevices":
+    get:
+      operationId: getGrafanaNetworkDevices
+      tags:
+      - Grafana
+      summary: Get Grafana network devices dashboard
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      responses:
+        '200':
+          description: Get Grafana network devices dashboard
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GetGrafanaDashboardLinkResponse"
+              examples:
+                example:
+                  summary: Grafana network devices dashboard link
+                  value:
+                    code: 200
+                    data:
+                      link: http://example-data-center/grafana/d/i-device/device?refresh=5m&orgId=1
+                      enabled: true
+                    msg: fetch network devices link successfully
+                    status: ok
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to get Grafana network devices dashboard: internal
+                      server error'
+                  status:
+                    type: string
+                    example: internal server error
   "/api/v1/datacenters/{dataCenter}/grafana/storages":
     get:
       operationId: getGrafanaStorages

--- a/docs.yaml
+++ b/docs.yaml
@@ -884,6 +884,21 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       - "$ref": "#/components/parameters/watch"
+      - in: query
+        name: past
+        required: false
+        schema:
+          type: string
+          enum:
+          - 1h
+          - 24h
+          - 7d
+          - 14d
+          - 30d
+        description: The past time of the health to query, click 'try it out' to see
+          a few options, but can specify with the 's'(second), 'm'(minute), 'h'(hour),
+          and 'd'(day) suffix for other time ranges.
+        example: 1h
       responses:
         '200':
           description: Retrieve the list of health successfully
@@ -1656,8 +1671,6 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       - "$ref": "#/components/parameters/keyword"
-      - "$ref": "#/components/parameters/product"
-      - "$ref": "#/components/parameters/licenseStatus"
       - in: query
         name: type
         required: false
@@ -1705,11 +1718,7 @@ paths:
                         quantity:
                           type: ''
                           value: 0
-                        serviceLevelAgreement:
-                          uptime: 0
-                          period: ''
-                          meanTimeBetweenFailure: ''
-                          meanTimeToRecovery: ''
+                        serviceLevelAgreement: 5x8
                         expiry:
                           date: '2025-05-15T17:31:21+08:00'
                           days: 56
@@ -1834,7 +1843,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/PostLicenseResponse"
+                "$ref": "#/components/schemas/VerifyLicenseResponse"
               examples:
                 example1:
                   summary: License verification result
@@ -2848,9 +2857,9 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       - "$ref": "#/components/parameters/keyword"
-      - "$ref": "#/components/parameters/product"
-      - "$ref": "#/components/parameters/role"
+      - "$ref": "#/components/parameters/roles"
       - "$ref": "#/components/parameters/licenseStatus"
+      - "$ref": "#/components/parameters/product"
       - "$ref": "#/components/parameters/pageSize"
       - "$ref": "#/components/parameters/pageNum"
       - "$ref": "#/components/parameters/watch"
@@ -2877,12 +2886,14 @@ paths:
                         ip: 10.10.10.10
                         managementIP: 10.10.10.10
                         license:
+                          name: example-license
                           type: trial
                           hostname: example-node-0
                           serial: 1H2ZLG2
                           product:
-                            name: ''
-                            features: 
+                            name: CubeCOS
+                            features:
+                            - virtualization
                           issue:
                             by: Bigstack co., ltd.
                             to: bigstack
@@ -2891,11 +2902,7 @@ paths:
                           quantity:
                             type: ''
                             value: 0
-                          serviceLevelAgreement:
-                            uptime: 0
-                            period: ''
-                            meanTimeBetweenFailure: ''
-                            meanTimeToRecovery: ''
+                          serviceLevelAgreement: 5x8
                           expiry:
                             date: '2025-03-24T14:51:50+08:00'
                             days: 9
@@ -2923,530 +2930,546 @@ paths:
                           state: DOWN
                           speed: NA/1000F
                         blockDevices:
-                        - device: nbd0
-                          type: disk
+                        - serial: ''
+                          device: nbd0
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd1
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd1
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd10
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd10
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd11
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd11
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd12
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd12
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd13
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd13
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd14
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd14
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd15
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd15
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd2
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd2
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd3
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd3
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd4
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd4
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd5
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd5
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd6
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd6
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd7
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd7
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd8
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd8
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: nbd9
-                          type: disk
+                          status: can be added
+                        - serial: ''
+                          device: nbd9
+                          type: SSD
                           sizeMiB: 0
-                          status: available
-                        - device: sda
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sda1
-                          type: part
+                          status: can be added
+                        - serial: S7M18BP3
+                          device: sda1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sda2
-                          type: part
+                          status: in-use
+                        - serial: S7M18BP3
+                          device: sda2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sda3
-                          type: part
+                          status: in-use
+                        - serial: S7M18BP3
+                          device: sda3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sda4
-                          type: part
+                          status: can be added
+                        - serial: S7M18BP3
+                          device: sda4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdb
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdb1
-                          type: part
+                          status: can be added
+                        - serial: S7M18KMS
+                          device: sdb1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdb2
-                          type: part
+                          status: in-use
+                        - serial: S7M18KMS
+                          device: sdb2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdb3
-                          type: part
+                          status: in-use
+                        - serial: S7M18KMS
+                          device: sdb3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdb4
-                          type: part
+                          status: can be added
+                        - serial: S7M18KMS
+                          device: sdb4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdc
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdc1
-                          type: part
+                          status: can be added
+                        - serial: S7M109S0
+                          device: sdc1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdc2
-                          type: part
+                          status: in-use
+                        - serial: S7M109S0
+                          device: sdc2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdc3
-                          type: part
+                          status: in-use
+                        - serial: S7M109S0
+                          device: sdc3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdc4
-                          type: part
+                          status: can be added
+                        - serial: S7M109S0
+                          device: sdc4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdd
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdd1
-                          type: part
+                          status: can be added
+                        - serial: S7M15TDF
+                          device: sdd1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdd2
-                          type: part
+                          status: in-use
+                        - serial: S7M15TDF
+                          device: sdd2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdd3
-                          type: part
+                          status: in-use
+                        - serial: S7M15TDF
+                          device: sdd3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdd4
-                          type: part
+                          status: can be added
+                        - serial: S7M15TDF
+                          device: sdd4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sde
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sde1
-                          type: part
+                          status: can be added
+                        - serial: S7M18BYG
+                          device: sde1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sde2
-                          type: part
+                          status: in-use
+                        - serial: S7M18BYG
+                          device: sde2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sde3
-                          type: part
+                          status: in-use
+                        - serial: S7M18BYG
+                          device: sde3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sde4
-                          type: part
+                          status: can be added
+                        - serial: S7M18BYG
+                          device: sde4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdf
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdf1
-                          type: part
+                          status: can be added
+                        - serial: S7M16KGY
+                          device: sdf1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdf2
-                          type: part
+                          status: in-use
+                        - serial: S7M16KGY
+                          device: sdf2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdf3
-                          type: part
+                          status: in-use
+                        - serial: S7M16KGY
+                          device: sdf3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdf4
-                          type: part
+                          status: can be added
+                        - serial: S7M16KGY
+                          device: sdf4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdg
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdg1
-                          type: part
+                          status: can be added
+                        - serial: S7M18J0Q
+                          device: sdg1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdg2
-                          type: part
+                          status: in-use
+                        - serial: S7M18J0Q
+                          device: sdg2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdg3
-                          type: part
+                          status: in-use
+                        - serial: S7M18J0Q
+                          device: sdg3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdg4
-                          type: part
+                          status: can be added
+                        - serial: S7M18J0Q
+                          device: sdg4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdh
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdh1
-                          type: part
+                          status: can be added
+                        - serial: S7M18LAY
+                          device: sdh1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdh2
-                          type: part
+                          status: in-use
+                        - serial: S7M18LAY
+                          device: sdh2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdh3
-                          type: part
+                          status: in-use
+                        - serial: S7M18LAY
+                          device: sdh3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdh4
-                          type: part
+                          status: can be added
+                        - serial: S7M18LAY
+                          device: sdh4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdi
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdi1
-                          type: part
+                          status: can be added
+                        - serial: S7M16LZ1
+                          device: sdi1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdi2
-                          type: part
+                          status: in-use
+                        - serial: S7M16LZ1
+                          device: sdi2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdi3
-                          type: part
+                          status: in-use
+                        - serial: S7M16LZ1
+                          device: sdi3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdi4
-                          type: part
+                          status: can be added
+                        - serial: S7M16LZ1
+                          device: sdi4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdj
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdj1
-                          type: part
+                          status: can be added
+                        - serial: S7M16LV3
+                          device: sdj1
+                          type: HDD
                           sizeMiB: 953.6743
-                          status: storage
-                        - device: sdj5
-                          type: part
+                          status: in-use
+                        - serial: S7M16LV3
+                          device: sdj5
+                          type: HDD
                           sizeMiB: 239467.6208
-                          status: storage
-                        - device: sdj6
-                          type: part
+                          status: in-use
+                        - serial: S7M16LV3
+                          device: sdj6
+                          type: HDD
                           sizeMiB: 239467.6208
-                          status: available
-                        - device: sdj7
-                          type: part
+                          status: can be added
+                        - serial: S7M16LV3
+                          device: sdj7
+                          type: HDD
                           sizeMiB: 53215.0268
-                          status: storage
-                        - device: sdk
-                          type: disk
-                          sizeMiB: 532531.7382
-                          status: available
-                        - device: sdk1
-                          type: part
+                          status: in-use
+                        - serial: 00df8523095cd5922b00617260a06d86
+                          device: sdk1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdk2
-                          type: part
+                          status: in-use
+                        - serial: 00df8523095cd5922b00617260a06d86
+                          device: sdk2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdk3
-                          type: part
+                          status: in-use
+                        - serial: 00df8523095cd5922b00617260a06d86
+                          device: sdk3
+                          type: HDD
                           sizeMiB: 265884.3994
-                          status: available
-                        - device: sdk4
-                          type: part
+                          status: can be added
+                        - serial: 00df8523095cd5922b00617260a06d86
+                          device: sdk4
+                          type: HDD
                           sizeMiB: 265884.3994
-                          status: available
-                        - device: sdl
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdl1
-                          type: part
+                          status: can be added
+                        - serial: S7M16LSA
+                          device: sdl1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdl2
-                          type: part
+                          status: in-use
+                        - serial: S7M16LSA
+                          device: sdl2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdl3
-                          type: part
+                          status: in-use
+                        - serial: S7M16LSA
+                          device: sdl3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdl4
-                          type: part
+                          status: can be added
+                        - serial: S7M16LSA
+                          device: sdl4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdm
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdm1
-                          type: part
+                          status: can be added
+                        - serial: S7M0ZYQ0
+                          device: sdm1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdm2
-                          type: part
+                          status: in-use
+                        - serial: S7M0ZYQ0
+                          device: sdm2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdm3
-                          type: part
+                          status: in-use
+                        - serial: S7M0ZYQ0
+                          device: sdm3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdm4
-                          type: part
+                          status: can be added
+                        - serial: S7M0ZYQ0
+                          device: sdm4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdn
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdn1
-                          type: part
+                          status: can be added
+                        - serial: S7M1414M
+                          device: sdn1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdn2
-                          type: part
+                          status: in-use
+                        - serial: S7M1414M
+                          device: sdn2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdn3
-                          type: part
+                          status: in-use
+                        - serial: S7M1414M
+                          device: sdn3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdn4
-                          type: part
+                          status: can be added
+                        - serial: S7M1414M
+                          device: sdn4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdo
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdo1
-                          type: part
+                          status: can be added
+                        - serial: S7M12FRA
+                          device: sdo1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdo2
-                          type: part
+                          status: in-use
+                        - serial: S7M12FRA
+                          device: sdo2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdo3
-                          type: part
+                          status: in-use
+                        - serial: S7M12FRA
+                          device: sdo3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdo4
-                          type: part
+                          status: can be added
+                        - serial: S7M12FRA
+                          device: sdo4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdp
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdp1
-                          type: part
+                          status: can be added
+                        - serial: S7M18JW0
+                          device: sdp1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdp2
-                          type: part
+                          status: in-use
+                        - serial: S7M18JW0
+                          device: sdp2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdp3
-                          type: part
+                          status: in-use
+                        - serial: S7M18JW0
+                          device: sdp3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdp4
-                          type: part
+                          status: can be added
+                        - serial: S7M18JW0
+                          device: sdp4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdq
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdq1
-                          type: part
+                          status: can be added
+                        - serial: S7M140R9
+                          device: sdq1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdq2
-                          type: part
+                          status: in-use
+                        - serial: S7M140R9
+                          device: sdq2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdq3
-                          type: part
+                          status: in-use
+                        - serial: S7M140R9
+                          device: sdq3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdq4
-                          type: part
+                          status: can be added
+                        - serial: S7M140R9
+                          device: sdq4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdr
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdr1
-                          type: part
+                          status: can be added
+                        - serial: S7M18JVW
+                          device: sdr1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdr2
-                          type: part
+                          status: in-use
+                        - serial: S7M18JVW
+                          device: sdr2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdr3
-                          type: part
+                          status: in-use
+                        - serial: S7M18JVW
+                          device: sdr3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdr4
-                          type: part
+                          status: can be added
+                        - serial: S7M18JVW
+                          device: sdr4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sds
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sds1
-                          type: part
+                          status: can be added
+                        - serial: S7M16LSF
+                          device: sds1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sds2
-                          type: part
+                          status: in-use
+                        - serial: S7M16LSF
+                          device: sds2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sds3
-                          type: part
+                          status: in-use
+                        - serial: S7M16LSF
+                          device: sds3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sds4
-                          type: part
+                          status: can be added
+                        - serial: S7M16LSF
+                          device: sds4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdt
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdt1
-                          type: part
+                          status: can be added
+                        - serial: S7M18JBV
+                          device: sdt1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdt2
-                          type: part
+                          status: in-use
+                        - serial: S7M18JBV
+                          device: sdt2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdt3
-                          type: part
+                          status: in-use
+                        - serial: S7M18JBV
+                          device: sdt3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdt4
-                          type: part
+                          status: can be added
+                        - serial: S7M18JBV
+                          device: sdt4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdu
-                          type: disk
-                          sizeMiB: 533008.5754
-                          status: available
-                        - device: sdu1
-                          type: part
+                          status: can be added
+                        - serial: S7M17CKC
+                          device: sdu1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdu2
-                          type: part
+                          status: in-use
+                        - serial: S7M17CKC
+                          device: sdu2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdu3
-                          type: part
+                          status: in-use
+                        - serial: S7M17CKC
+                          device: sdu3
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdu4
-                          type: part
+                          status: can be added
+                        - serial: S7M17CKC
+                          device: sdu4
+                          type: HDD
                           sizeMiB: 266170.5017
-                          status: available
-                        - device: sdv
-                          type: disk
-                          sizeMiB: 532531.7382
-                          status: available
-                        - device: sdv1
-                          type: part
+                          status: can be added
+                        - serial: 002c73230a6dd5922b00617260a06d86
+                          device: sdv1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdv2
-                          type: part
+                          status: in-use
+                        - serial: 002c73230a6dd5922b00617260a06d86
+                          device: sdv2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdv3
-                          type: part
+                          status: in-use
+                        - serial: 002c73230a6dd5922b00617260a06d86
+                          device: sdv3
+                          type: HDD
                           sizeMiB: 265884.3994
-                          status: available
-                        - device: sdv4
-                          type: part
+                          status: can be added
+                        - serial: 002c73230a6dd5922b00617260a06d86
+                          device: sdv4
+                          type: HDD
                           sizeMiB: 265884.3994
-                          status: available
-                        - device: sdw
-                          type: disk
-                          sizeMiB: 532531.7382
-                          status: available
-                        - device: sdw1
-                          type: part
+                          status: can be added
+                        - serial: 0070ba2a2f379c7c2b00617260a06d86
+                          device: sdw1
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdw2
-                          type: part
+                          status: in-use
+                        - serial: 0070ba2a2f379c7c2b00617260a06d86
+                          device: sdw2
+                          type: HDD
                           sizeMiB: 381.4697
-                          status: storage
-                        - device: sdw3
-                          type: part
+                          status: in-use
+                        - serial: 0070ba2a2f379c7c2b00617260a06d86
+                          device: sdw3
+                          type: HDD
                           sizeMiB: 265884.3994
-                          status: available
-                        - device: sdw4
-                          type: part
+                          status: can be added
+                        - serial: 0070ba2a2f379c7c2b00617260a06d86
+                          device: sdw4
+                          type: HDD
                           sizeMiB: 265884.3994
-                          status: available
+                          status: can be added
                         vcpu:
                           totalCores: 48
                           usedCores: 40
@@ -3529,12 +3552,14 @@ paths:
                       ip: 10.10.10.10
                       managementIP: 10.10.10.10
                       license:
+                        name: example-license
                         type: trial
                         hostname: example-node-0
                         serial: 1H2ZLG2
                         product:
-                          name: ''
-                          features: 
+                          name: CubeCOS
+                          features:
+                          - virtualization
                         issue:
                           by: Bigstack co., ltd.
                           to: bigstack
@@ -3543,11 +3568,7 @@ paths:
                         quantity:
                           type: ''
                           value: 0
-                        serviceLevelAgreement:
-                          uptime: 0
-                          period: ''
-                          meanTimeBetweenFailure: ''
-                          meanTimeToRecovery: ''
+                        serviceLevelAgreement: 5x8
                         expiry:
                           date: '2025-03-24T14:51:50+08:00'
                           days: 9
@@ -3575,530 +3596,546 @@ paths:
                         state: DOWN
                         speed: NA/1000F
                       blockDevices:
-                      - device: nbd0
-                        type: disk
+                      - serial: ''
+                        device: nbd0
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd1
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd1
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd10
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd10
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd11
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd11
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd12
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd12
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd13
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd13
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd14
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd14
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd15
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd15
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd2
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd2
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd3
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd3
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd4
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd4
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd5
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd5
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd6
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd6
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd7
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd7
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd8
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd8
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: nbd9
-                        type: disk
+                        status: can be added
+                      - serial: ''
+                        device: nbd9
+                        type: SSD
                         sizeMiB: 0
-                        status: available
-                      - device: sda
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sda1
-                        type: part
+                        status: can be added
+                      - serial: S7M18BP3
+                        device: sda1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sda2
-                        type: part
+                        status: in-use
+                      - serial: S7M18BP3
+                        device: sda2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sda3
-                        type: part
+                        status: in-use
+                      - serial: S7M18BP3
+                        device: sda3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sda4
-                        type: part
+                        status: can be added
+                      - serial: S7M18BP3
+                        device: sda4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdb
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdb1
-                        type: part
+                        status: can be added
+                      - serial: S7M18KMS
+                        device: sdb1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdb2
-                        type: part
+                        status: in-use
+                      - serial: S7M18KMS
+                        device: sdb2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdb3
-                        type: part
+                        status: in-use
+                      - serial: S7M18KMS
+                        device: sdb3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdb4
-                        type: part
+                        status: can be added
+                      - serial: S7M18KMS
+                        device: sdb4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdc
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdc1
-                        type: part
+                        status: can be added
+                      - serial: S7M109S0
+                        device: sdc1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdc2
-                        type: part
+                        status: in-use
+                      - serial: S7M109S0
+                        device: sdc2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdc3
-                        type: part
+                        status: in-use
+                      - serial: S7M109S0
+                        device: sdc3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdc4
-                        type: part
+                        status: can be added
+                      - serial: S7M109S0
+                        device: sdc4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdd
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdd1
-                        type: part
+                        status: can be added
+                      - serial: S7M15TDF
+                        device: sdd1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdd2
-                        type: part
+                        status: in-use
+                      - serial: S7M15TDF
+                        device: sdd2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdd3
-                        type: part
+                        status: in-use
+                      - serial: S7M15TDF
+                        device: sdd3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdd4
-                        type: part
+                        status: can be added
+                      - serial: S7M15TDF
+                        device: sdd4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sde
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sde1
-                        type: part
+                        status: can be added
+                      - serial: S7M18BYG
+                        device: sde1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sde2
-                        type: part
+                        status: in-use
+                      - serial: S7M18BYG
+                        device: sde2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sde3
-                        type: part
+                        status: in-use
+                      - serial: S7M18BYG
+                        device: sde3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sde4
-                        type: part
+                        status: can be added
+                      - serial: S7M18BYG
+                        device: sde4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdf
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdf1
-                        type: part
+                        status: can be added
+                      - serial: S7M16KGY
+                        device: sdf1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdf2
-                        type: part
+                        status: in-use
+                      - serial: S7M16KGY
+                        device: sdf2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdf3
-                        type: part
+                        status: in-use
+                      - serial: S7M16KGY
+                        device: sdf3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdf4
-                        type: part
+                        status: can be added
+                      - serial: S7M16KGY
+                        device: sdf4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdg
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdg1
-                        type: part
+                        status: can be added
+                      - serial: S7M18J0Q
+                        device: sdg1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdg2
-                        type: part
+                        status: in-use
+                      - serial: S7M18J0Q
+                        device: sdg2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdg3
-                        type: part
+                        status: in-use
+                      - serial: S7M18J0Q
+                        device: sdg3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdg4
-                        type: part
+                        status: can be added
+                      - serial: S7M18J0Q
+                        device: sdg4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdh
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdh1
-                        type: part
+                        status: can be added
+                      - serial: S7M18LAY
+                        device: sdh1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdh2
-                        type: part
+                        status: in-use
+                      - serial: S7M18LAY
+                        device: sdh2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdh3
-                        type: part
+                        status: in-use
+                      - serial: S7M18LAY
+                        device: sdh3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdh4
-                        type: part
+                        status: can be added
+                      - serial: S7M18LAY
+                        device: sdh4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdi
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdi1
-                        type: part
+                        status: can be added
+                      - serial: S7M16LZ1
+                        device: sdi1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdi2
-                        type: part
+                        status: in-use
+                      - serial: S7M16LZ1
+                        device: sdi2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdi3
-                        type: part
+                        status: in-use
+                      - serial: S7M16LZ1
+                        device: sdi3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdi4
-                        type: part
+                        status: can be added
+                      - serial: S7M16LZ1
+                        device: sdi4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdj
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdj1
-                        type: part
+                        status: can be added
+                      - serial: S7M16LV3
+                        device: sdj1
+                        type: HDD
                         sizeMiB: 953.6743
-                        status: storage
-                      - device: sdj5
-                        type: part
+                        status: in-use
+                      - serial: S7M16LV3
+                        device: sdj5
+                        type: HDD
                         sizeMiB: 239467.6208
-                        status: storage
-                      - device: sdj6
-                        type: part
+                        status: in-use
+                      - serial: S7M16LV3
+                        device: sdj6
+                        type: HDD
                         sizeMiB: 239467.6208
-                        status: available
-                      - device: sdj7
-                        type: part
+                        status: can be added
+                      - serial: S7M16LV3
+                        device: sdj7
+                        type: HDD
                         sizeMiB: 53215.0268
-                        status: storage
-                      - device: sdk
-                        type: disk
-                        sizeMiB: 532531.7382
-                        status: available
-                      - device: sdk1
-                        type: part
+                        status: in-use
+                      - serial: 00df8523095cd5922b00617260a06d86
+                        device: sdk1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdk2
-                        type: part
+                        status: in-use
+                      - serial: 00df8523095cd5922b00617260a06d86
+                        device: sdk2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdk3
-                        type: part
+                        status: in-use
+                      - serial: 00df8523095cd5922b00617260a06d86
+                        device: sdk3
+                        type: HDD
                         sizeMiB: 265884.3994
-                        status: available
-                      - device: sdk4
-                        type: part
+                        status: can be added
+                      - serial: 00df8523095cd5922b00617260a06d86
+                        device: sdk4
+                        type: HDD
                         sizeMiB: 265884.3994
-                        status: available
-                      - device: sdl
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdl1
-                        type: part
+                        status: can be added
+                      - serial: S7M16LSA
+                        device: sdl1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdl2
-                        type: part
+                        status: in-use
+                      - serial: S7M16LSA
+                        device: sdl2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdl3
-                        type: part
+                        status: in-use
+                      - serial: S7M16LSA
+                        device: sdl3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdl4
-                        type: part
+                        status: can be added
+                      - serial: S7M16LSA
+                        device: sdl4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdm
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdm1
-                        type: part
+                        status: can be added
+                      - serial: S7M0ZYQ0
+                        device: sdm1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdm2
-                        type: part
+                        status: in-use
+                      - serial: S7M0ZYQ0
+                        device: sdm2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdm3
-                        type: part
+                        status: in-use
+                      - serial: S7M0ZYQ0
+                        device: sdm3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdm4
-                        type: part
+                        status: can be added
+                      - serial: S7M0ZYQ0
+                        device: sdm4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdn
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdn1
-                        type: part
+                        status: can be added
+                      - serial: S7M1414M
+                        device: sdn1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdn2
-                        type: part
+                        status: in-use
+                      - serial: S7M1414M
+                        device: sdn2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdn3
-                        type: part
+                        status: in-use
+                      - serial: S7M1414M
+                        device: sdn3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdn4
-                        type: part
+                        status: can be added
+                      - serial: S7M1414M
+                        device: sdn4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdo
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdo1
-                        type: part
+                        status: can be added
+                      - serial: S7M12FRA
+                        device: sdo1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdo2
-                        type: part
+                        status: in-use
+                      - serial: S7M12FRA
+                        device: sdo2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdo3
-                        type: part
+                        status: in-use
+                      - serial: S7M12FRA
+                        device: sdo3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdo4
-                        type: part
+                        status: can be added
+                      - serial: S7M12FRA
+                        device: sdo4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdp
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdp1
-                        type: part
+                        status: can be added
+                      - serial: S7M18JW0
+                        device: sdp1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdp2
-                        type: part
+                        status: in-use
+                      - serial: S7M18JW0
+                        device: sdp2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdp3
-                        type: part
+                        status: in-use
+                      - serial: S7M18JW0
+                        device: sdp3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdp4
-                        type: part
+                        status: can be added
+                      - serial: S7M18JW0
+                        device: sdp4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdq
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdq1
-                        type: part
+                        status: can be added
+                      - serial: S7M140R9
+                        device: sdq1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdq2
-                        type: part
+                        status: in-use
+                      - serial: S7M140R9
+                        device: sdq2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdq3
-                        type: part
+                        status: in-use
+                      - serial: S7M140R9
+                        device: sdq3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdq4
-                        type: part
+                        status: can be added
+                      - serial: S7M140R9
+                        device: sdq4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdr
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdr1
-                        type: part
+                        status: can be added
+                      - serial: S7M18JVW
+                        device: sdr1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdr2
-                        type: part
+                        status: in-use
+                      - serial: S7M18JVW
+                        device: sdr2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdr3
-                        type: part
+                        status: in-use
+                      - serial: S7M18JVW
+                        device: sdr3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdr4
-                        type: part
+                        status: can be added
+                      - serial: S7M18JVW
+                        device: sdr4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sds
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sds1
-                        type: part
+                        status: can be added
+                      - serial: S7M16LSF
+                        device: sds1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sds2
-                        type: part
+                        status: in-use
+                      - serial: S7M16LSF
+                        device: sds2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sds3
-                        type: part
+                        status: in-use
+                      - serial: S7M16LSF
+                        device: sds3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sds4
-                        type: part
+                        status: can be added
+                      - serial: S7M16LSF
+                        device: sds4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdt
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdt1
-                        type: part
+                        status: can be added
+                      - serial: S7M18JBV
+                        device: sdt1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdt2
-                        type: part
+                        status: in-use
+                      - serial: S7M18JBV
+                        device: sdt2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdt3
-                        type: part
+                        status: in-use
+                      - serial: S7M18JBV
+                        device: sdt3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdt4
-                        type: part
+                        status: can be added
+                      - serial: S7M18JBV
+                        device: sdt4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdu
-                        type: disk
-                        sizeMiB: 533008.5754
-                        status: available
-                      - device: sdu1
-                        type: part
+                        status: can be added
+                      - serial: S7M17CKC
+                        device: sdu1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdu2
-                        type: part
+                        status: in-use
+                      - serial: S7M17CKC
+                        device: sdu2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdu3
-                        type: part
+                        status: in-use
+                      - serial: S7M17CKC
+                        device: sdu3
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdu4
-                        type: part
+                        status: can be added
+                      - serial: S7M17CKC
+                        device: sdu4
+                        type: HDD
                         sizeMiB: 266170.5017
-                        status: available
-                      - device: sdv
-                        type: disk
-                        sizeMiB: 532531.7382
-                        status: available
-                      - device: sdv1
-                        type: part
+                        status: can be added
+                      - serial: 002c73230a6dd5922b00617260a06d86
+                        device: sdv1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdv2
-                        type: part
+                        status: in-use
+                      - serial: 002c73230a6dd5922b00617260a06d86
+                        device: sdv2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdv3
-                        type: part
+                        status: in-use
+                      - serial: 002c73230a6dd5922b00617260a06d86
+                        device: sdv3
+                        type: HDD
                         sizeMiB: 265884.3994
-                        status: available
-                      - device: sdv4
-                        type: part
+                        status: can be added
+                      - serial: 002c73230a6dd5922b00617260a06d86
+                        device: sdv4
+                        type: HDD
                         sizeMiB: 265884.3994
-                        status: available
-                      - device: sdw
-                        type: disk
-                        sizeMiB: 532531.7382
-                        status: available
-                      - device: sdw1
-                        type: part
+                        status: can be added
+                      - serial: 0070ba2a2f379c7c2b00617260a06d86
+                        device: sdw1
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdw2
-                        type: part
+                        status: in-use
+                      - serial: 0070ba2a2f379c7c2b00617260a06d86
+                        device: sdw2
+                        type: HDD
                         sizeMiB: 381.4697
-                        status: storage
-                      - device: sdw3
-                        type: part
+                        status: in-use
+                      - serial: 0070ba2a2f379c7c2b00617260a06d86
+                        device: sdw3
+                        type: HDD
                         sizeMiB: 265884.3994
-                        status: available
-                      - device: sdw4
-                        type: part
+                        status: can be added
+                      - serial: 0070ba2a2f379c7c2b00617260a06d86
+                        device: sdw4
+                        type: HDD
                         sizeMiB: 265884.3994
-                        status: available
+                        status: can be added
                       vcpu:
                         totalCores: 48
                         usedCores: 40
@@ -6784,12 +6821,12 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       - "$ref": "#/components/parameters/watch"
+      - "$ref": "#/components/parameters/roles"
+      - "$ref": "#/components/parameters/start"
+      - "$ref": "#/components/parameters/stop"
       - "$ref": "#/components/parameters/pageSize"
       - "$ref": "#/components/parameters/pageNum"
       - "$ref": "#/components/parameters/keyword"
-      - "$ref": "#/components/parameters/role"
-      - "$ref": "#/components/parameters/start"
-      - "$ref": "#/components/parameters/stop"
       responses:
         '200':
           description: Retrieve support files successfully
@@ -7429,30 +7466,21 @@ components:
         type: string
       description: The keyword to search, can be any string
       example: example-keyword
-    product:
+    roles:
       in: query
-      name: product
-      required: false
-      schema: 
-        type: string
-        enum: 
-          - CubeCOS
-          - CubeCMP
-      description: The type of product to query, the value can be 'CubeCOS' or 'CubeCMP'.
-      example: CubeCOS
-    role:
-      in: query
-      name: role
+      name: roles
       required: false
       schema:
-        type: string
-        enum:
-        - control-converged
-        - control
-        - compute
-        - storage
-        - edge-core
-        - moderator
+        type: array
+        items:
+          type: string
+          enum:
+          - control-converged
+          - control
+          - compute
+          - storage
+          - edge-core
+          - moderator
       description: The role of the host
       example: control-converged
     licenseStatus:
@@ -7468,6 +7496,17 @@ components:
         - error
       description: The status of the host
       example: active
+    product:
+      in: query
+      name: product
+      required: false
+      schema:
+        type: string
+        enum:
+        - cubeCOS
+        - cubeCMP
+      description: The product of the host
+      example: example-product
     metricType:
       in: path
       name: metricType
@@ -7998,12 +8037,17 @@ components:
                     type: object
                     required:
                     - current
+                    - isFixing
                     properties:
                       current:
                         type: string
                         enum:
                         - ok
                         - ng
+                      isFixing:
+                        type: boolean
+                      description:
+                        type: string
                   modules:
                     type: array
                     required:
@@ -8022,12 +8066,17 @@ components:
                           type: object
                           required:
                           - current
+                          - isFixing
                           properties:
                             current:
                               type: string
                               enum:
                               - ok
                               - ng
+                            isFixing:
+                              type: boolean
+                            description:
+                              type: string
         msg:
           type: string
           example: fetch health successfully
@@ -8314,21 +8363,7 @@ components:
                       value:
                         type: integer
                   serviceLevelAgreement:
-                    type: object
-                    required:
-                    - uptime
-                    - period
-                    - meanTimeBetweenFailure
-                    - meanTimeToRecovery
-                    properties:
-                      uptime:
-                        type: number
-                      period:
-                        type: string
-                      meanTimeBetweenFailure:
-                        type: string
-                      meanTimeToRecovery:
-                        type: string
+                    type: string
                   expiry:
                     type: object
                     required:
@@ -8367,19 +8402,6 @@ components:
           type: string
           format: binary
           description: License file (must have a .license extension)
-    PostLicenseResponse:
-      type: object
-      required:
-      - code
-      - msg
-      - status
-      properties:
-        code:
-          type: integer
-        msg:
-          type: string
-        status:
-          type: string
     VerifyLicenseResponse:
       type: object
       required:
@@ -8514,6 +8536,19 @@ components:
                         - expired
                       isExpiring:
                         type: boolean
+        msg:
+          type: string
+        status:
+          type: string
+    PostLicenseResponse:
+      type: object
+      required:
+      - code
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
         msg:
           type: string
         status:
@@ -10540,6 +10575,7 @@ components:
         license:
           type: object
           required:
+          - name
           - type
           - hostname
           - serial
@@ -10593,21 +10629,7 @@ components:
                 value:
                   type: integer
             serviceLevelAgreement:
-              type: object
-              required:
-              - uptime
-              - period
-              - meanTimeBetweenFailure
-              - meanTimeToRe
-              properties:
-                uptime:
-                  type: integer
-                period:
-                  type: string
-                meanTimeBetweenFailure:
-                  type: string
-                meanTimeToRecovery:
-                  type: string
+              type: string
             expiry:
               type: object
               required:
@@ -10649,11 +10671,14 @@ components:
           items:
             type: object
             required:
+            - serial
             - device
             - type
             - sizeMiB
             - status
             properties:
+              serial:
+                type: string
               device:
                 type: string
               type:

--- a/docs.yaml
+++ b/docs.yaml
@@ -1671,19 +1671,9 @@ paths:
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
       - "$ref": "#/components/parameters/keyword"
-      - in: query
-        name: type
-        required: false
-        schema:
-          type: string
-          enum:
-          - trial
-          - perpetual
-          - community
-          - enterprise
-        description: The type of the license to query, click 'try it out' to see a
-          few options.
-        example: trial
+      - "$ref": "#/components/parameters/products"
+      - "$ref": "#/components/parameters/statuses"
+      - "$ref": "#/components/parameters/types"
       - "$ref": "#/components/parameters/pageSize"
       - "$ref": "#/components/parameters/pageNum"
       - "$ref": "#/components/parameters/watch"
@@ -2858,8 +2848,8 @@ paths:
       - "$ref": "#/components/parameters/dataCenter"
       - "$ref": "#/components/parameters/keyword"
       - "$ref": "#/components/parameters/roles"
-      - "$ref": "#/components/parameters/licenseStatus"
-      - "$ref": "#/components/parameters/product"
+      - "$ref": "#/components/parameters/licenseStatuses"
+      - "$ref": "#/components/parameters/products"
       - "$ref": "#/components/parameters/pageSize"
       - "$ref": "#/components/parameters/pageNum"
       - "$ref": "#/components/parameters/watch"
@@ -2885,6 +2875,7 @@ paths:
                         address: 10.10.10.10:8001
                         ip: 10.10.10.10
                         managementIP: 10.10.10.10
+                        storageIP: 10.10.10.10
                         license:
                           name: example-license
                           type: trial
@@ -3551,6 +3542,7 @@ paths:
                       address: 10.10.10.10:8001
                       ip: 10.10.10.10
                       managementIP: 10.10.10.10
+                      storageIP: 10.10.10.10
                       license:
                         name: example-license
                         type: trial
@@ -5057,7 +5049,7 @@ paths:
                         enabled: true
                         isModified: false
                         limitation:
-                          type: bool
+                          type: boolean
                           default: false
                         status:
                           current: updating
@@ -5074,7 +5066,7 @@ paths:
                         enabled: true
                         isModified: false
                         limitation:
-                          type: string
+                          type: str
                           default: ''
                           regex: ''
                         status:
@@ -5091,7 +5083,7 @@ paths:
                         enabled: true
                         isModified: false
                         limitation:
-                          type: bool
+                          type: boolean
                           default: false
                         status:
                           current: ok
@@ -5107,7 +5099,7 @@ paths:
                         enabled: true
                         isModified: false
                         limitation:
-                          type: string
+                          type: str
                           default: ''
                           regex: ''
                         status:
@@ -5219,7 +5211,7 @@ paths:
                     - name: barbican.debug.enabled
                       description: Set to true to enable barbican verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5229,7 +5221,7 @@ paths:
                     - name: ceph.debug.enabled
                       description: Set to true to enable ceph debug logs.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5240,7 +5232,7 @@ paths:
                       description: Set to true to enable automatically volume metadata
                         sync.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: true
                       roles:
                       - name: control-converged
@@ -5250,7 +5242,7 @@ paths:
                     - name: cinder.backup.account
                       description: Set cinder backup storage account.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5260,7 +5252,7 @@ paths:
                     - name: cinder.backup.endpoint
                       description: Set cinder backup storage endpoint.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5270,7 +5262,7 @@ paths:
                     - name: cinder.backup.override
                       description: Enable override cinder backup configurations.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5280,7 +5272,7 @@ paths:
                     - name: cinder.backup.pool
                       description: Set cinder backup storage pool.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5290,7 +5282,7 @@ paths:
                     - name: cinder.backup.secret
                       description: Set cinder backup storage account secret.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5300,7 +5292,7 @@ paths:
                     - name: cinder.backup.type
                       description: Set cinder backup storage type <cube-storage|cube-swift>.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5310,7 +5302,7 @@ paths:
                     - name: cinder.debug.enabled
                       description: Set to true to enable cinder verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5320,7 +5312,7 @@ paths:
                     - name: cinder.external.%d.account
                       description: Set cinder external storage account.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5330,7 +5322,7 @@ paths:
                     - name: cinder.external.%d.driver
                       description: Set cinder external storage type name <cube|purestorage>.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5340,7 +5332,7 @@ paths:
                     - name: cinder.external.%d.endpoint
                       description: Set cinder external storage endpoint.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5350,7 +5342,7 @@ paths:
                     - name: cinder.external.%d.name
                       description: Set cinder external storage rule name.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5360,7 +5352,7 @@ paths:
                     - name: cinder.external.%d.pool
                       description: Set cinder external storage pool.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5370,7 +5362,7 @@ paths:
                     - name: cinder.external.%d.secret
                       description: Set cinder external storage account secret.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5431,7 +5423,7 @@ paths:
                       description: Set extra provider interfaces ('pvd-' prefix and
                         <= 15 chars) [IF.2:pvd-xxx,eth2:pvd-yyy,...].
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles:
                       - name: control-converged
@@ -5441,7 +5433,7 @@ paths:
                     - name: cyborg.debug.enabled
                       description: Set to true to enable cyborg verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5451,7 +5443,7 @@ paths:
                     - name: debug.enable_core_dump.%s
                       description: Enable core dump for process %s
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5461,7 +5453,7 @@ paths:
                     - name: debug.enable_kdump
                       description: Enable kdump to collect dump from kernel panic
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5496,7 +5488,7 @@ paths:
                     - name: designate.debug.enabled
                       description: Set to true to enable designate verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5506,7 +5498,7 @@ paths:
                     - name: glance.debug.enabled
                       description: Set to true to enable glance verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5528,7 +5520,7 @@ paths:
                     - name: heat.debug.enabled
                       description: Set to true to enable heat verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5550,7 +5542,7 @@ paths:
                     - name: ironic.debug.enabled
                       description: Set to true to enable ironic verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5560,7 +5552,7 @@ paths:
                     - name: ironic.deploy.server
                       description: Set to true to enable ironic deploy server (dhcp/tftp/pxe/http).
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5570,7 +5562,7 @@ paths:
                     - name: kapacitor.alert.check.enabled
                       description: Set true to enable kapacitor alert check.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5580,7 +5572,7 @@ paths:
                     - name: kapacitor.alert.check.eventid
                       description: Set kapacitor alert check eventid.
                       limitation:
-                        type: string
+                        type: str
                         default: SYS00002W
                       roles:
                       - name: control-converged
@@ -5591,7 +5583,7 @@ paths:
                       description: Set kapacitor alert check interval (default to
                         60m).
                       limitation:
-                        type: string
+                        type: str
                         default: 60m
                       roles:
                       - name: control-converged
@@ -5601,7 +5593,7 @@ paths:
                     - name: kapacitor.alert.extra.prefix
                       description: Set kapacitor alert message prefix.
                       limitation:
-                        type: string
+                        type: str
                         default: Cube
                       roles:
                       - name: control-converged
@@ -5611,7 +5603,7 @@ paths:
                     - name: kapacitor.alert.flow.base
                       description: Set kapacitor alert base for abnormal flow.
                       limitation:
-                        type: string
+                        type: str
                         default: 7d
                       roles:
                       - name: control-converged
@@ -5633,7 +5625,7 @@ paths:
                     - name: kapacitor.alert.flow.unit
                       description: Set kapacitor alert unit for abnormal flow.
                       limitation:
-                        type: string
+                        type: str
                         default: 5m
                       roles:
                       - name: control-converged
@@ -5643,7 +5635,7 @@ paths:
                     - name: keystone.debug.enabled
                       description: Set to true to enable keystone verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5653,7 +5645,7 @@ paths:
                     - name: manila.debug.enabled
                       description: Set to true to enable manila verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5663,7 +5655,7 @@ paths:
                     - name: manila.volume.type
                       description: Set manila backend volume type.
                       limitation:
-                        type: string
+                        type: str
                         default: CubeStorage
                       roles:
                       - name: control-converged
@@ -5674,7 +5666,7 @@ paths:
                       description: Set to true to enable evacuate all instances when
                         host goes down.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: true
                       roles:
                       - name: control-converged
@@ -5696,7 +5688,7 @@ paths:
                     - name: monasca.debug.enabled
                       description: Set to true to enable monasca verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5731,7 +5723,7 @@ paths:
                     - name: net.ipv4.tcp_syncookies
                       description: Turn on the Linux SYN cookies implementation.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: true
                       roles:
                       - name: control-converged
@@ -5741,7 +5733,7 @@ paths:
                     - name: net.lacp.default.rate
                       description: Set default LACP rate (fast/slow).
                       limitation:
-                        type: string
+                        type: str
                         default: fast
                       roles:
                       - name: control-converged
@@ -5751,7 +5743,7 @@ paths:
                     - name: net.lacp.default.xmit
                       description: Set default LACP transmit hash policy (layer2/layer2+3/layer3+4).
                       limitation:
-                        type: string
+                        type: str
                         default: layer3+4
                       roles:
                       - name: control-converged
@@ -5761,7 +5753,7 @@ paths:
                     - name: neutron.debug.enabled
                       description: Set to true to enable neutron verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5796,7 +5788,7 @@ paths:
                     - name: nova.debug.enabled
                       description: Set to true to enable nova verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5806,7 +5798,7 @@ paths:
                     - name: nova.gpu.type
                       description: Specify a supported gpu type instances would get.
                       limitation:
-                        type: string
+                        type: str
                         default: ''
                       roles: []
                     - name: nova.overcommit.cpu.ratio
@@ -5842,7 +5834,7 @@ paths:
                     - name: ntp.debug.enabled
                       description: Set to true to enable ntp verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5852,7 +5844,7 @@ paths:
                     - name: octavia.debug.enabled
                       description: Set to true to enable octavia verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5862,7 +5854,7 @@ paths:
                     - name: octavia.ha
                       description: Set to true to enable octavia HA mode.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5896,7 +5888,7 @@ paths:
                     - name: senlin.debug.enabled
                       description: Set to true to enable senlin verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5906,7 +5898,7 @@ paths:
                     - name: skyline.debug.enabled
                       description: Set to true to enable skyline verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5916,7 +5908,7 @@ paths:
                     - name: snapshot.apply.action
                       description: Set snapshot apply action <apply|revert>.
                       limitation:
-                        type: string
+                        type: str
                         default: apply
                       roles:
                       - name: control-converged
@@ -5926,7 +5918,7 @@ paths:
                     - name: snapshot.apply.policy.ignore
                       description: Set snapshot apply policy ignore <true|false>.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5936,7 +5928,7 @@ paths:
                     - name: sshd.bind_to_all_interfaces
                       description: Set to true to bind sshd to all interfaces.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5958,7 +5950,7 @@ paths:
                     - name: time.timezone
                       description: Set system timezone.
                       limitation:
-                        type: string
+                        type: str
                         default: UTC
                       roles:
                       - name: control-converged
@@ -5968,7 +5960,7 @@ paths:
                     - name: update.security.autoupdate
                       description: Set to true to enable security autoupdate.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -5978,7 +5970,7 @@ paths:
                     - name: watcher.debug.enabled
                       description: Set to true to enable watcher verbose log.
                       limitation:
-                        type: bool
+                        type: boolean
                         default: false
                       roles:
                       - name: control-converged
@@ -7541,30 +7533,65 @@ components:
           - moderator
       description: The role of the host
       example: control-converged
-    licenseStatus:
+    statuses:
       in: query
-      name: licenseStatus
+      name: statuses
       required: false
       schema:
-        type: string
-        enum:
-        - ok
-        - expiring
-        - expired
-        - error
+        type: array
+        items:
+          type: string
+          enum:
+          - ok
+          - expiring
+          - expired
+          - error
       description: The status of the host
       example: active
-    product:
+    types:
       in: query
-      name: product
+      name: types
       required: false
       schema:
-        type: string
-        enum:
-        - cubeCOS
-        - cubeCMP
+        type: array
+        items:
+          type: string
+          enum:
+          - trial
+          - perpetual
+          - community
+          - enterprise
+      description: The type of the license to query, click 'try it out' to see a few
+        options.
+      example: trial
+    licenseStatuses:
+      in: query
+      name: licenseStatuses
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+          - ok
+          - expiring
+          - expired
+          - error
+      description: The status of the host
+      example: active
+    products:
+      in: query
+      name: products
+      required: false
+      schema:
+        type: array
+        items:
+          type: string
+          enum:
+          - cubeCOS
+          - cubeCMP
       description: The product of the host
-      example: example-product
+      example: cubeCOS
     metricType:
       in: path
       name: metricType
@@ -10044,16 +10071,13 @@ components:
                     oneOf:
                     - type: string
                     - type: integer
-                    - type: number
                     - type: boolean
                   min:
                     oneOf:
                     - type: integer
-                    - type: number
                   max:
                     oneOf:
                     - type: integer
-                    - type: number
                   regex:
                     type: string
               roles:
@@ -10597,10 +10621,10 @@ components:
       - dataCenter
       - hostname
       - role
-      - protocol
       - address
       - ip
       - managementIP
+      - storageIP
       - license
       - status
       - cpuSpec
@@ -10622,13 +10646,13 @@ components:
           type: string
         role:
           type: string
-        protocol:
-          type: string
         address:
           type: string
         ip:
           type: string
         managementIP:
+          type: string
+        storageIP:
           type: string
         license:
           type: object
@@ -10643,6 +10667,8 @@ components:
           - serviceLevelAgreement
           - expiry
           properties:
+            name:
+              type: string
             type:
               type: string
             hostname:
@@ -10897,7 +10923,7 @@ components:
     TuningLimitationType:
       type: string
       enum:
-      - string
+      - str
       - int
-      - float
-      - bool
+      - uint
+      - boolean


### PR DESCRIPTION
### What type of PR is this?

Refactor

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cube-cos-api/pull/182

<br/>

### What this PR does?

Major:

- node details: add a new field "serial" in storage list

- node details: adjust the example for type and status field in storage list

- grafana: add a new GET api to fetch the link of network devices dashboard

<br/>

Minor:

- license: adjust SLA type to string rather than object

- license: adjust the corresponding SLA example as well

- healths: support past query for health summary
 


<br/>

### Test results (optional)

1). make sure no error from the online swagger editor and CI

![Screenshot 2025-04-11 at 8 45 43 AM](https://github.com/user-attachments/assets/94851d11-8535-4f5e-9f31-1f8080d14bc2)

