### PR TITLE
fix: get metrics api response array

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -8963,7 +8963,9 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/TimeValuePair"
+          type: array
+          items:
+            "$ref": "#/components/schemas/TimeValuePair"
         msg:
           type: string
         status:
@@ -8979,7 +8981,9 @@ components:
         code:
           type: integer
         data:
-          "$ref": "#/components/schemas/TimeValuePair"
+          type: array
+          items:
+            "$ref": "#/components/schemas/TimeValuePair"
         msg:
           type: string
         status:


### PR DESCRIPTION
### What type of PR is this?

Fix

### What this PR does?

Change the `data` type of `GetCpuUsageHistoryOfHostResponse` and `GetMemoryUsageHistoryOfHostResponse` from `TimeValuePair` to `TimeValuePair[]`.

### Test results (optional)

![image](https://github.com/user-attachments/assets/7412346d-677d-4a56-9678-c9292e3f33f5)

