### PR TITLE
Adjust the doc for trigger api and metric api

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -2770,38 +2770,40 @@ paths:
           content:
             application/json:
               schema:
-                oneOf:
-                - "$ref": "#/components/schemas/GetCpuUsageHistoryOfHostResponse"
-                - "$ref": "#/components/schemas/GetMemoryUsageHistoryOfHostResponse"
+                "$ref": "#/components/schemas/HostMetricHistoryResponse"
               examples:
                 example1:
                   summary: Cpu usage history of host
                   value:
                     code: 200
                     data:
-                    - time: '2025-03-24T09:39:00+08:00'
-                      value: 10.9059
-                    - time: '2025-03-24T09:40:00+08:00'
-                      value: 10.5089
-                    - time: '2025-03-24T09:41:00+08:00'
-                      value: 15.3512
-                    - time: '2025-03-24T09:42:00+08:00'
-                      value: 12.3685
+                      unit: percentage
+                      history:
+                      - time: '2025-03-24T09:39:00+08:00'
+                        value: 10.9059
+                      - time: '2025-03-24T09:40:00+08:00'
+                        value: 10.5089
+                      - time: '2025-03-24T09:41:00+08:00'
+                        value: 15.3512
+                      - time: '2025-03-24T09:42:00+08:00'
+                        value: 12.3685
                     msg: fetch metrics successfully
                     status: ok
                 example2:
-                  summary: Memory usage history of host
+                  summary: Memory size history of host
                   value:
                     code: 200
                     data:
-                    - time: '2025-03-24T07:06:00+08:00'
-                      value: 55.9796
-                    - time: '2025-03-24T07:07:00+08:00'
-                      value: 55.9997
-                    - time: '2025-03-24T07:08:00+08:00'
-                      value: 55.9884
-                    - time: '2025-03-24T07:09:00+08:00'
-                      value: 55.9449
+                      unit: sizeMiB
+                      history:
+                      - time: '2025-04-15T05:42:00+08:00'
+                        value: 25918.1601
+                      - time: '2025-04-15T05:43:00+08:00'
+                        value: 26017.2656
+                      - time: '2025-04-15T05:44:00+08:00'
+                        value: 25927.0429
+                      - time: '2025-04-15T05:45:00+08:00'
+                        value: 25998.707
                     msg: fetch metrics successfully
                     status: ok
         '400':
@@ -8961,7 +8963,7 @@ components:
         status:
           type: string
           example: ok
-    GetCpuUsageHistoryOfHostResponse:
+    HostMetricHistoryResponse:
       type: object
       required:
       - code
@@ -8972,27 +8974,17 @@ components:
         code:
           type: integer
         data:
-          type: array
-          items:
-            "$ref": "#/components/schemas/TimeValuePair"
-        msg:
-          type: string
-        status:
-          type: string
-    GetMemoryUsageHistoryOfHostResponse:
-      type: object
-      required:
-      - code
-      - data
-      - msg
-      - status
-      properties:
-        code:
-          type: integer
-        data:
-          type: array
-          items:
-            "$ref": "#/components/schemas/TimeValuePair"
+          type: object
+          required:
+          - unit
+          - history
+          properties:
+            unit:
+              type: string
+            history:
+              type: array
+              items:
+                "$ref": "#/components/schemas/TimeValuePair"
         msg:
           type: string
         status:

--- a/docs.yaml
+++ b/docs.yaml
@@ -6357,12 +6357,15 @@ paths:
                         - name: amqp-alert-p1
                           url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
                           description: example slack channel 1
+                          enabled: false
                         - name: "#test-cos-300-notification"
                           url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
                           description: example slack channel 2
+                          enabled: false
                         emails:
                         - address: example.user@example.com
                           note: example email recipient
+                          enabled: false
                       status:
                         isUpdating: false
                       enabled: false
@@ -6418,12 +6421,15 @@ paths:
                         - name: amqp-alert-p1
                           url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
                           description: example slack channel 1
+                          enabled: false
                         - name: "#test-cos-300-notification"
                           url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
                           description: example slack channel 2
+                          enabled: false
                         emails:
                         - address: example.user@example.com
                           note: example email recipient
+                          enabled: false
                       status:
                         isUpdating: false
                       enabled: false
@@ -6485,7 +6491,7 @@ paths:
                 "$ref": "#/components/schemas/GetTriggerResponse"
               examples:
                 example:
-                  summary: Get a specific trigger
+                  summary: Trigger
                   value:
                     code: 200
                     data:
@@ -6542,12 +6548,15 @@ paths:
                         - name: amqp-alert-p1
                           url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
                           description: example slack channel 1
+                          enabled: false
                         - name: "#test-cos-300-notification"
                           url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
                           description: example slack channel 2
+                          enabled: false
                         emails:
                         - address: example.user@example.com
                           note: example email recipient
+                          enabled: false
                       enabled: false
                     msg: fetch trigger successfully
                     status: ok
@@ -6653,7 +6662,7 @@ paths:
                     - url: https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>
                     emails:
                     - address: example.user@example.com
-                  enabled: false
+                  description: example-update-description
       responses:
         '202':
           description: Update trigger request received
@@ -10234,6 +10243,7 @@ components:
                       - name
                       - url
                       - description
+                      - enabled
                       properties:
                         name:
                           type: string
@@ -10241,6 +10251,8 @@ components:
                           type: string
                         description:
                           type: string
+                        enabled:
+                          type: boolean
                   emails:
                     type: array
                     items:
@@ -10248,11 +10260,14 @@ components:
                       required:
                       - address
                       - note
+                      - enabled
                       properties:
                         address:
                           type: string
                         note:
                           type: string
+                        enabled:
+                          type: boolean
               status:
                 type: object
                 required:
@@ -10329,6 +10344,7 @@ components:
                     - name
                     - url
                     - description
+                    - enabled
                     properties:
                       name:
                         type: string
@@ -10336,6 +10352,8 @@ components:
                         type: string
                       description:
                         type: string
+                      enabled:
+                        type: boolean
                 emails:
                   type: array
                   items:
@@ -10343,11 +10361,14 @@ components:
                     required:
                     - email
                     - note
+                    - enabled
                     properties:
                       email:
                         type: string
                       note:
                         type: string
+                      enabled:
+                        type: boolean
             enabled:
               type: boolean
         msg:
@@ -10361,7 +10382,7 @@ components:
       required:
       - attributes
       - response
-      - enabled
+      - description
       properties:
         attributes:
           type: array
@@ -10371,7 +10392,6 @@ components:
             - name
             - type
             - value
-            - enabled
             properties:
               name:
                 type: string
@@ -10379,8 +10399,6 @@ components:
                 type: string
               value:
                 type: string
-              enabled:
-                type: boolean
         response:
           type: object
           required:
@@ -10405,8 +10423,8 @@ components:
                 properties:
                   address:
                     type: string
-        enabled:
-          type: boolean
+        description:
+          type: string
     EnableOrDisableTriggerRequest:
       type: object
       required:


### PR DESCRIPTION
### What type of PR is this?

Refactor and fix

<br/>

### Which issue(s) this PR fixes?

cos-api: triggers - https://github.com/bigstack-oss/cube-cos-api/pull/194

cos-api: metrics - https://github.com/bigstack-oss/cube-cos-api/pull/196

<br/>

### What this PR does?

📔 Changes already synced to staging 113 and 150, can have a trial on both envs

- Triggers: Add 'description' in the PATCH trigger api

- Triggers: Adjust the schema 'enable' to 'enabled' in the whole trigger api scope

- Metrics: Adjust the cpu and memory history response schema for single host



<br/>

### Test results (optional)

1). make sure no error from the online swagger editor and CI

<img width="1723" alt="Screenshot 2025-04-15 at 7 29 42 AM" src="https://github.com/user-attachments/assets/af5c1627-6278-47f1-bfba-1c76874d4a72" />


