### PR TITLE
fix: settings update title prefix body

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -4248,7 +4248,12 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/TitlePrefix"
+              type: object
+              required:
+                - value
+              properties:
+                value:
+                  type: string
             examples:
               example:
                 summary: Title prefix


### PR DESCRIPTION
### What type of PR is this?

Fix

### What this PR does?

Change the request body schema of the update title prefix endpoint from `TitlePrefix` to `{ value: string }`.

### Test results (optional)

- Before
   - <img width="614" alt="{A0911573-95F3-43B5-A635-20C572572738}" src="https://github.com/user-attachments/assets/67c140f1-99ae-4491-8982-1412437c2ce5" />
- After
   - ![image](https://github.com/user-attachments/assets/5ada657c-63a2-48d3-a884-98b8c1d7237e)
