### PR TITLE
Adjust/add the license status in the node, data center and license api

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -1680,7 +1680,7 @@ paths:
       - "$ref": "#/components/parameters/dataCenter"
       - "$ref": "#/components/parameters/keyword"
       - "$ref": "#/components/parameters/products"
-      - "$ref": "#/components/parameters/statuses"
+      - "$ref": "#/components/parameters/listLicenseStatuses"
       - "$ref": "#/components/parameters/types"
       - "$ref": "#/components/parameters/pageSize"
       - "$ref": "#/components/parameters/pageNum"
@@ -2851,7 +2851,7 @@ paths:
       - "$ref": "#/components/parameters/dataCenter"
       - "$ref": "#/components/parameters/keyword"
       - "$ref": "#/components/parameters/roles"
-      - "$ref": "#/components/parameters/licenseStatuses"
+      - "$ref": "#/components/parameters/nodeLicenseStatuses"
       - "$ref": "#/components/parameters/products"
       - "$ref": "#/components/parameters/pageSize"
       - "$ref": "#/components/parameters/pageNum"
@@ -6524,21 +6524,16 @@ components:
           - moderator
       description: The role of the host
       example: control-converged
-    statuses:
+    listLicenseStatuses:
       in: query
       name: statuses
       required: false
       schema:
         type: array
         items:
-          type: string
-          enum:
-          - ok
-          - expiring
-          - expired
-          - error
-      description: The status of the host
-      example: active
+          $ref: '#/components/schemas/ListLicenseCurrentStatus'
+      description: The status of the license
+      example: valid
     types:
       in: query
       name: types
@@ -6555,21 +6550,16 @@ components:
       description: The type of the license to query, click 'try it out' to see a few
         options.
       example: trial
-    licenseStatuses:
+    nodeLicenseStatuses:
       in: query
       name: licenseStatuses
       required: false
       schema:
         type: array
         items:
-          type: string
-          enum:
-          - ok
-          - expiring
-          - expired
-          - error
-      description: The status of the host
-      example: active
+          $ref: '#/components/schemas/NodeLicenseCurrentStatus'
+      description: The license status of the host
+      example: valid
     products:
       in: query
       name: products
@@ -7590,19 +7580,7 @@ components:
                       days:
                         type: integer
                   status:
-                    type: object
-                    required:
-                    - current
-                    - isExpiring
-                    properties:
-                      current:
-                        type: string
-                        enum:
-                        - ok
-                        - expiring
-                        - expired
-                      isExpiring:
-                        type: boolean
+                    $ref: "#/components/schemas/NodeLicenseStatus"
         msg:
           type: string
         status:
@@ -9930,6 +9908,11 @@ components:
       - int
       - uint
       - bool
+    ListLicenseCurrentStatus:
+      type: string
+      enum:
+        - valid
+        - expired
     ListLicenseStatus:
       type: object
       required:
@@ -9937,12 +9920,15 @@ components:
       - isExpiring
       properties:
         current:
-          type: string
-          enum:
-          - valid
-          - expired
+          $ref: "#/components/schemas/ListLicenseCurrentStatus"
         isExpiring:
           type: boolean
+    NodeLicenseCurrentStatus:
+      type: string
+      enum:
+      - unlicense
+      - valid
+      - expired
     NodeLicenseStatus:
       type: object
       required:
@@ -9950,11 +9936,7 @@ components:
       - isExpiring
       properties:
         current:
-          type: string
-          enum:
-          - unlicense
-          - valid
-          - expired
+          $ref: "#/components/schemas/NodeLicenseCurrentStatus"
         isExpiring:
           type: boolean
     VerifyLicenseStatus:

--- a/docs.yaml
+++ b/docs.yaml
@@ -82,6 +82,10 @@ paths:
                       utcTimeZone: "+00:00"
                       additional:
                         helpUrl: https://www.bigstack.co/contact-us
+                        nodeLicenseStatus:
+                          valid: 3
+                          expired: 0
+                          unlicense: 0
                     msg: fetch data center list successfully
                     status: ok
         '500':
@@ -130,6 +134,10 @@ paths:
                       utcTimeZone: "+00:00"
                       additional:
                         helpUrl: https://www.bigstack.co/contact-us
+                        nodeLicenseStatus:
+                          valid: 3
+                          expired: 0
+                          unlicense: 0
                     msg: fetch data center info successfully
                     status: ok
         '500':
@@ -1709,7 +1717,7 @@ paths:
                           date: '2025-05-15T17:31:21+08:00'
                           days: 56
                         status:
-                          current: ok
+                          current: valid
                           isExpiring: false
                       page:
                         total: 1
@@ -1853,8 +1861,8 @@ paths:
                           date: '2025-05-09T19:16:13+08:00'
                           days: 29
                         status:
-                          current: expiring
-                          isExpiring: true
+                          current: valid
+                          isExpiring: false
                       effectNodes:
                       - name: example-node-1
                         role: control-converged
@@ -1862,24 +1870,24 @@ paths:
                           date: '2025-05-09T19:16:13+08:00'
                           days: 30
                         status:
-                          current: expiring
-                          isExpiring: true
+                          current: valid
+                          isExpiring: false
                       - name: example-node-2
                         role: control-converged
                         expiry:
                           date: '2025-05-09T19:16:13+08:00'
                           days: 30
                         status:
-                          current: expiring
-                          isExpiring: true
+                          current: valid
+                          isExpiring: false
                       - name: example-node-3
                         role: control-converged
                         expiry:
                           date: '2025-05-09T19:16:13+08:00'
                           days: 30
                         status:
-                          current: expiring
-                          isExpiring: true
+                          current: valid
+                          isExpiring: false
                     msg: verify license successfully
                     status: ok
         '401':
@@ -2889,6 +2897,9 @@ paths:
                           expiry:
                             date: '2025-03-24T14:51:50+08:00'
                             days: 9
+                          status:
+                            current: valid
+                            isExpiring: true
                         status: up
                         cpuSpec: Intel(R) Xeon(R) CPU E5-2650 v4 @ 2.20GHz
                         networkInterfaces:
@@ -2913,546 +2924,16 @@ paths:
                           state: DOWN
                           speed: NA/1000F
                         blockDevices:
-                        - serial: ''
-                          device: nbd0
+                        - serial: '200264800526'
+                          device: nvme0n1
                           type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd1
+                          sizeMiB: 222110.7482
+                          status: system
+                        - serial: '200598804038'
+                          device: nvme1n1
                           type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd10
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd11
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd12
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd13
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd14
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd15
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd2
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd3
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd4
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd5
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd6
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd7
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd8
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: ''
-                          device: nbd9
-                          type: SSD
-                          sizeMiB: 0
-                          status: can be added
-                        - serial: S7M18BP3
-                          device: sda1
-                          type: HDD
-                          sizeMiB: 381.4697
+                          sizeMiB: 222110.7482
                           status: in-use
-                        - serial: S7M18BP3
-                          device: sda2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18BP3
-                          device: sda3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18BP3
-                          device: sda4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18KMS
-                          device: sdb1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18KMS
-                          device: sdb2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18KMS
-                          device: sdb3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18KMS
-                          device: sdb4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M109S0
-                          device: sdc1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M109S0
-                          device: sdc2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M109S0
-                          device: sdc3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M109S0
-                          device: sdc4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M15TDF
-                          device: sdd1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M15TDF
-                          device: sdd2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M15TDF
-                          device: sdd3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M15TDF
-                          device: sdd4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18BYG
-                          device: sde1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18BYG
-                          device: sde2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18BYG
-                          device: sde3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18BYG
-                          device: sde4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M16KGY
-                          device: sdf1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M16KGY
-                          device: sdf2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M16KGY
-                          device: sdf3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M16KGY
-                          device: sdf4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18J0Q
-                          device: sdg1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18J0Q
-                          device: sdg2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18J0Q
-                          device: sdg3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18J0Q
-                          device: sdg4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18LAY
-                          device: sdh1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18LAY
-                          device: sdh2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18LAY
-                          device: sdh3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18LAY
-                          device: sdh4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M16LZ1
-                          device: sdi1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M16LZ1
-                          device: sdi2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M16LZ1
-                          device: sdi3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M16LZ1
-                          device: sdi4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M16LV3
-                          device: sdj1
-                          type: HDD
-                          sizeMiB: 953.6743
-                          status: in-use
-                        - serial: S7M16LV3
-                          device: sdj5
-                          type: HDD
-                          sizeMiB: 239467.6208
-                          status: in-use
-                        - serial: S7M16LV3
-                          device: sdj6
-                          type: HDD
-                          sizeMiB: 239467.6208
-                          status: can be added
-                        - serial: S7M16LV3
-                          device: sdj7
-                          type: HDD
-                          sizeMiB: 53215.0268
-                          status: in-use
-                        - serial: 00df8523095cd5922b00617260a06d86
-                          device: sdk1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: 00df8523095cd5922b00617260a06d86
-                          device: sdk2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: 00df8523095cd5922b00617260a06d86
-                          device: sdk3
-                          type: HDD
-                          sizeMiB: 265884.3994
-                          status: can be added
-                        - serial: 00df8523095cd5922b00617260a06d86
-                          device: sdk4
-                          type: HDD
-                          sizeMiB: 265884.3994
-                          status: can be added
-                        - serial: S7M16LSA
-                          device: sdl1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M16LSA
-                          device: sdl2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M16LSA
-                          device: sdl3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M16LSA
-                          device: sdl4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M0ZYQ0
-                          device: sdm1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M0ZYQ0
-                          device: sdm2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M0ZYQ0
-                          device: sdm3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M0ZYQ0
-                          device: sdm4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M1414M
-                          device: sdn1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M1414M
-                          device: sdn2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M1414M
-                          device: sdn3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M1414M
-                          device: sdn4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M12FRA
-                          device: sdo1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M12FRA
-                          device: sdo2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M12FRA
-                          device: sdo3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M12FRA
-                          device: sdo4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18JW0
-                          device: sdp1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18JW0
-                          device: sdp2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18JW0
-                          device: sdp3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18JW0
-                          device: sdp4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M140R9
-                          device: sdq1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M140R9
-                          device: sdq2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M140R9
-                          device: sdq3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M140R9
-                          device: sdq4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18JVW
-                          device: sdr1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18JVW
-                          device: sdr2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18JVW
-                          device: sdr3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18JVW
-                          device: sdr4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M16LSF
-                          device: sds1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M16LSF
-                          device: sds2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M16LSF
-                          device: sds3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M16LSF
-                          device: sds4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18JBV
-                          device: sdt1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18JBV
-                          device: sdt2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M18JBV
-                          device: sdt3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M18JBV
-                          device: sdt4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M17CKC
-                          device: sdu1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M17CKC
-                          device: sdu2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: S7M17CKC
-                          device: sdu3
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: S7M17CKC
-                          device: sdu4
-                          type: HDD
-                          sizeMiB: 266170.5017
-                          status: can be added
-                        - serial: 002c73230a6dd5922b00617260a06d86
-                          device: sdv1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: 002c73230a6dd5922b00617260a06d86
-                          device: sdv2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: 002c73230a6dd5922b00617260a06d86
-                          device: sdv3
-                          type: HDD
-                          sizeMiB: 265884.3994
-                          status: can be added
-                        - serial: 002c73230a6dd5922b00617260a06d86
-                          device: sdv4
-                          type: HDD
-                          sizeMiB: 265884.3994
-                          status: can be added
-                        - serial: 0070ba2a2f379c7c2b00617260a06d86
-                          device: sdw1
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: 0070ba2a2f379c7c2b00617260a06d86
-                          device: sdw2
-                          type: HDD
-                          sizeMiB: 381.4697
-                          status: in-use
-                        - serial: 0070ba2a2f379c7c2b00617260a06d86
-                          device: sdw3
-                          type: HDD
-                          sizeMiB: 265884.3994
-                          status: can be added
-                        - serial: 0070ba2a2f379c7c2b00617260a06d86
-                          device: sdw4
-                          type: HDD
-                          sizeMiB: 265884.3994
-                          status: can be added
                         vcpu:
                           totalCores: 48
                           usedCores: 40
@@ -3553,6 +3034,9 @@ paths:
                         expiry:
                           date: '2025-03-24T14:51:50+08:00'
                           days: 9
+                        status:
+                          current: valid
+                          isExpiring: true
                       status: up
                       cpuSpec: Intel(R) Xeon(R) CPU E5-2650 v4 @ 2.20GHz
                       networkInterfaces:
@@ -3577,546 +3061,16 @@ paths:
                         state: DOWN
                         speed: NA/1000F
                       blockDevices:
-                      - serial: ''
-                        device: nbd0
+                      - serial: '200264800526'
+                        device: nvme0n1
                         type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd1
+                        sizeMiB: 222110.7482
+                        status: system
+                      - serial: '200598804038'
+                        device: nvme1n1
                         type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd10
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd11
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd12
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd13
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd14
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd15
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd2
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd3
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd4
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd5
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd6
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd7
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd8
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: ''
-                        device: nbd9
-                        type: SSD
-                        sizeMiB: 0
-                        status: can be added
-                      - serial: S7M18BP3
-                        device: sda1
-                        type: HDD
-                        sizeMiB: 381.4697
+                        sizeMiB: 222110.7482
                         status: in-use
-                      - serial: S7M18BP3
-                        device: sda2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18BP3
-                        device: sda3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18BP3
-                        device: sda4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18KMS
-                        device: sdb1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18KMS
-                        device: sdb2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18KMS
-                        device: sdb3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18KMS
-                        device: sdb4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M109S0
-                        device: sdc1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M109S0
-                        device: sdc2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M109S0
-                        device: sdc3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M109S0
-                        device: sdc4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M15TDF
-                        device: sdd1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M15TDF
-                        device: sdd2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M15TDF
-                        device: sdd3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M15TDF
-                        device: sdd4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18BYG
-                        device: sde1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18BYG
-                        device: sde2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18BYG
-                        device: sde3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18BYG
-                        device: sde4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M16KGY
-                        device: sdf1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M16KGY
-                        device: sdf2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M16KGY
-                        device: sdf3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M16KGY
-                        device: sdf4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18J0Q
-                        device: sdg1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18J0Q
-                        device: sdg2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18J0Q
-                        device: sdg3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18J0Q
-                        device: sdg4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18LAY
-                        device: sdh1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18LAY
-                        device: sdh2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18LAY
-                        device: sdh3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18LAY
-                        device: sdh4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M16LZ1
-                        device: sdi1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M16LZ1
-                        device: sdi2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M16LZ1
-                        device: sdi3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M16LZ1
-                        device: sdi4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M16LV3
-                        device: sdj1
-                        type: HDD
-                        sizeMiB: 953.6743
-                        status: in-use
-                      - serial: S7M16LV3
-                        device: sdj5
-                        type: HDD
-                        sizeMiB: 239467.6208
-                        status: in-use
-                      - serial: S7M16LV3
-                        device: sdj6
-                        type: HDD
-                        sizeMiB: 239467.6208
-                        status: can be added
-                      - serial: S7M16LV3
-                        device: sdj7
-                        type: HDD
-                        sizeMiB: 53215.0268
-                        status: in-use
-                      - serial: 00df8523095cd5922b00617260a06d86
-                        device: sdk1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: 00df8523095cd5922b00617260a06d86
-                        device: sdk2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: 00df8523095cd5922b00617260a06d86
-                        device: sdk3
-                        type: HDD
-                        sizeMiB: 265884.3994
-                        status: can be added
-                      - serial: 00df8523095cd5922b00617260a06d86
-                        device: sdk4
-                        type: HDD
-                        sizeMiB: 265884.3994
-                        status: can be added
-                      - serial: S7M16LSA
-                        device: sdl1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M16LSA
-                        device: sdl2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M16LSA
-                        device: sdl3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M16LSA
-                        device: sdl4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M0ZYQ0
-                        device: sdm1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M0ZYQ0
-                        device: sdm2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M0ZYQ0
-                        device: sdm3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M0ZYQ0
-                        device: sdm4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M1414M
-                        device: sdn1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M1414M
-                        device: sdn2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M1414M
-                        device: sdn3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M1414M
-                        device: sdn4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M12FRA
-                        device: sdo1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M12FRA
-                        device: sdo2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M12FRA
-                        device: sdo3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M12FRA
-                        device: sdo4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18JW0
-                        device: sdp1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18JW0
-                        device: sdp2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18JW0
-                        device: sdp3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18JW0
-                        device: sdp4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M140R9
-                        device: sdq1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M140R9
-                        device: sdq2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M140R9
-                        device: sdq3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M140R9
-                        device: sdq4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18JVW
-                        device: sdr1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18JVW
-                        device: sdr2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18JVW
-                        device: sdr3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18JVW
-                        device: sdr4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M16LSF
-                        device: sds1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M16LSF
-                        device: sds2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M16LSF
-                        device: sds3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M16LSF
-                        device: sds4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18JBV
-                        device: sdt1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18JBV
-                        device: sdt2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M18JBV
-                        device: sdt3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M18JBV
-                        device: sdt4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M17CKC
-                        device: sdu1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M17CKC
-                        device: sdu2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: S7M17CKC
-                        device: sdu3
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: S7M17CKC
-                        device: sdu4
-                        type: HDD
-                        sizeMiB: 266170.5017
-                        status: can be added
-                      - serial: 002c73230a6dd5922b00617260a06d86
-                        device: sdv1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: 002c73230a6dd5922b00617260a06d86
-                        device: sdv2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: 002c73230a6dd5922b00617260a06d86
-                        device: sdv3
-                        type: HDD
-                        sizeMiB: 265884.3994
-                        status: can be added
-                      - serial: 002c73230a6dd5922b00617260a06d86
-                        device: sdv4
-                        type: HDD
-                        sizeMiB: 265884.3994
-                        status: can be added
-                      - serial: 0070ba2a2f379c7c2b00617260a06d86
-                        device: sdw1
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: 0070ba2a2f379c7c2b00617260a06d86
-                        device: sdw2
-                        type: HDD
-                        sizeMiB: 381.4697
-                        status: in-use
-                      - serial: 0070ba2a2f379c7c2b00617260a06d86
-                        device: sdw3
-                        type: HDD
-                        sizeMiB: 265884.3994
-                        status: can be added
-                      - serial: 0070ba2a2f379c7c2b00617260a06d86
-                        device: sdw4
-                        type: HDD
-                        sizeMiB: 265884.3994
-                        status: can be added
                       vcpu:
                         totalCores: 48
                         usedCores: 40
@@ -4250,7 +3204,7 @@ paths:
             schema:
               type: object
               required:
-                - value
+              - value
               properties:
                 value:
                   type: string
@@ -7754,9 +6708,26 @@ components:
                 type: object
                 required:
                 - helpUrl
+                - nodeLicenseStatus
                 properties:
                   helpUrl:
                     type: string
+                  nodeLicenseStatus:
+                    type: object
+                    required:
+                    - valid
+                    - expired
+                    - unlicense
+                    properties:
+                      valid:
+                        type: integer
+                        example: 1
+                      expired:
+                        type: integer
+                        example: 0
+                      unlicense:
+                        type: integer
+                        example: 0
         msg:
           type: string
           example: fetch data center list successfully
@@ -7801,9 +6772,26 @@ components:
               type: object
               required:
               - helpUrl
+              - nodeLicenseStatus
               properties:
                 helpUrl:
                   type: string
+                nodeLicenseStatus:
+                  type: object
+                  required:
+                  - valid
+                  - expired
+                  - unlicense
+                  properties:
+                    valid:
+                      type: integer
+                      example: 1
+                    expired:
+                      type: integer
+                      example: 0
+                    unlicense:
+                      type: integer
+                      example: 0
         msg:
           type: string
           example: fetch data center successfully
@@ -8487,18 +7475,7 @@ components:
                       days:
                         type: integer
                   status:
-                    type: object
-                    required:
-                    - current
-                    - isExpiring
-                    properties:
-                      current:
-                        type: string
-                        enum:
-                        - ok
-                        - expired
-                      isExpiring:
-                        type: boolean
+                    "$ref": "#/components/schemas/ListLicenseStatus"
             page:
               "$ref": "#/components/schemas/Page"
         msg:
@@ -8587,19 +7564,7 @@ components:
                     days:
                       type: integer
                 status:
-                  type: object
-                  required:
-                  - current
-                  - isExpiring
-                  properties:
-                    current:
-                      type: string
-                      enum:
-                      - ok
-                      - expiring
-                      - expired
-                    isExpiring:
-                      type: boolean
+                  "$ref": "#/components/schemas/VerifyLicenseStatus"
             effectNodes:
               type: array
               items:
@@ -9536,8 +8501,6 @@ components:
       required:
       - host
       - port
-      - username
-      - password
       - email
       - status
       properties:
@@ -10711,6 +9674,7 @@ components:
           - quantity
           - supportPlan
           - expiry
+          - status
           properties:
             name:
               type: string
@@ -10762,6 +9726,8 @@ components:
                   format: date-time
                 days:
                   type: integer
+            status:
+              "$ref": "#/components/schemas/NodeLicenseStatus"
         status:
           type: string
         cpuSpec:
@@ -10964,6 +9930,49 @@ components:
       - int
       - uint
       - bool
+    ListLicenseStatus:
+      type: object
+      required:
+      - current
+      - isExpiring
+      properties:
+        current:
+          type: string
+          enum:
+          - valid
+          - expired
+        isExpiring:
+          type: boolean
+    NodeLicenseStatus:
+      type: object
+      required:
+      - current
+      - isExpiring
+      properties:
+        current:
+          type: string
+          enum:
+          - unlicense
+          - valid
+          - expired
+        isExpiring:
+          type: boolean
+    VerifyLicenseStatus:
+      type: object
+      required:
+      - current
+      - isExpiring
+      properties:
+        current:
+          type: string
+          enum:
+          - valid
+          - unmatched hardware
+          - invalid signature
+          - system compromised
+          - expired
+        isExpiring:
+          type: boolean
     SettingStatus:
       type: object
       required:


### PR DESCRIPTION
### What type of PR is this?

Refactor and fix

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cube-cos-api/pull/207

<br/>

### What this PR does?

as discussed for license status in the last week, we made a few adjustments below

<br/>

**1). Data center:**

- Add `node's license status` overview in the `additional`

<img width="1378" alt="Screenshot 2025-04-21 at 10 59 54 AM" src="https://github.com/user-attachments/assets/67992d48-5983-40e4-bfe4-b9599a0a781d" />

<img width="1377" alt="Screenshot 2025-04-21 at 11 00 12 AM" src="https://github.com/user-attachments/assets/81678fd0-20fb-43d8-8840-afc9d537a2b7" />

<br/>
<br/>
<br/>

**2). Node:**

- Add `node.license.status` in the node object (API do have it, but missed in the DOC)

⚠️ the status range here is `unlicense, valid, and expired`

<img width="1329" alt="Screenshot 2025-04-21 at 11 01 20 AM" src="https://github.com/user-attachments/assets/cd1fabfc-2203-4b8d-a5bb-95b58f349a04" />

<img width="1432" alt="Screenshot 2025-04-21 at 11 01 50 AM" src="https://github.com/user-attachments/assets/603327f2-2924-40a4-b999-629953539c2d" />

<br/>
<br/>
<br/>

**3). License:**

- Adjust `node.license.status` value scope in the node object

- Have a new field `node.license.status.isExpiring`

⚠️ the status range here is `valid, and expired`

<img width="1438" alt="Screenshot 2025-04-21 at 11 03 31 AM" src="https://github.com/user-attachments/assets/ed2a5fc3-f523-44ac-8dd8-3487dbb471ff" />

<br/>
<br/>
<br/>

**4). Others:**

- Adjust the example for node's block device list, to make it more close to the real case

- Remove email sender's username and password from `required`

<br/>
<br/>
<br/>

### Test results (optional)

1). make sure no error from the online swagger editor and CI

![Screenshot 2025-04-21 at 10 38 27 AM](https://github.com/user-attachments/assets/3a58a0fb-e3b3-4bfc-bc56-fddef6404310)




