### PR TITLE
Add data center type and allowed roles in the dat…

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -6719,7 +6719,9 @@ components:
           items:
             type: object
             required:
+            - type
             - name
+            - roles
             - version
             - virtualIp
             - isHaEnabled
@@ -6812,8 +6814,8 @@ components:
             type:
               type: string
               enum:
-                - cloud
-                - edge
+              - cloud
+              - edge
             name:
               type: string
             roles:

--- a/docs.yaml
+++ b/docs.yaml
@@ -6729,6 +6729,9 @@ components:
             properties:
               type:
                 type: string
+                enum:
+                - cloud
+                - edge
               name:
                 type: string
               roles:
@@ -6808,6 +6811,9 @@ components:
           properties:
             type:
               type: string
+              enum:
+                - cloud
+                - edge
             name:
               type: string
             roles:

--- a/docs.yaml
+++ b/docs.yaml
@@ -74,7 +74,13 @@ paths:
                   value:
                     code: 200
                     data:
-                    - name: example-data-center
+                    - type: cloud
+                      name: example-data-center
+                      roles:
+                      - control-converged
+                      - control
+                      - compute
+                      - storage
                       version: Cube Appliance 3.0.0
                       virtualIp: 10.10.10.10
                       isLocal: true
@@ -121,12 +127,41 @@ paths:
               schema:
                 "$ref": "#/components/schemas/GetDataCenterResponse"
               examples:
-                example:
-                  summary: Data center
+                example1:
+                  summary: Cloud type data center
                   value:
                     code: 200
                     data:
+                      type: cloud
                       name: example-data-center
+                      roles:
+                      - control-converged
+                      - control
+                      - compute
+                      - storage
+                      version: Cube Appliance 3.0.0
+                      virtualIp: 10.10.10.10
+                      isLocal: true
+                      isHaEnabled: false
+                      utcTimeZone: "+00:00"
+                      additional:
+                        helpUrl: https://www.bigstack.co/contact-us
+                        nodeLicenseStatus:
+                          valid: 3
+                          expired: 0
+                          unlicense: 0
+                    msg: fetch data center info successfully
+                    status: ok
+                example2:
+                  summary: Edge type data center
+                  value:
+                    code: 200
+                    data:
+                      type: edge
+                      name: example-data-center
+                      roles:
+                      - moderator
+                      - edge-core
                       version: Cube Appliance 3.0.0
                       virtualIp: 10.10.10.10
                       isLocal: true
@@ -6692,8 +6727,21 @@ components:
             - utcTimeZone
             - additional
             properties:
+              type:
+                type: string
               name:
                 type: string
+              roles:
+                type: array
+                items:
+                  type: string
+                  enum:
+                  - control-converged
+                  - control
+                  - compute
+                  - storage
+                  - edge-core
+                  - moderator
               version:
                 type: string
               virtualIp:
@@ -6748,7 +6796,9 @@ components:
         data:
           type: object
           required:
+          - type
           - name
+          - roles
           - version
           - virtualIp
           - isHaEnabled
@@ -6756,8 +6806,21 @@ components:
           - utcTimeZone
           - additional
           properties:
+            type:
+              type: string
             name:
               type: string
+            roles:
+              type: array
+              items:
+                type: string
+                enum:
+                - control-converged
+                - control
+                - compute
+                - storage
+                - edge-core
+                - moderator
             version:
               type: string
             virtualIp:


### PR DESCRIPTION
### What type of PR is this?

Refactor

<br/>

### Which issue(s) this PR fixes?

To align the https://github.com/bigstack-oss/cube-cos-api/pull/215

<br/>

### What this PR does?

<br/>

based on the recent UI adjustment for the role info and data center type usage, we've a few changes below for data center apis

- Add data center type

- Add allowed roles info for each different data center type

https://github.com/user-attachments/assets/27dca1d2-ca60-4709-b2fe-70ae4a507c49

https://github.com/user-attachments/assets/ad761710-3233-4335-9115-903e97d1628b

<br/>
<br/>
<br/>

### Test results (optional)

1). make sure no error from the online swagger editor and CI

![Screenshot 2025-04-24 at 5 50 44 PM](https://github.com/user-attachments/assets/9d222595-cffa-4680-959d-93c0352ec13b)




