### PR TITLE
fix(license): add `name` and `serial` response field

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -1734,7 +1734,8 @@ paths:
                     code: 200
                     data:
                       licenses:
-                      - type: trial
+                      - name: example-license
+                        type: trial
                         hosts:
                         - example-node-0
                         serial: 1H2ZLG2
@@ -1882,6 +1883,7 @@ paths:
                       license:
                         name: example-license
                         type: trial
+                        serial: 1H2ZLG2
                         product:
                           name: CubeCOS
                           feature: virtualization
@@ -7487,6 +7489,7 @@ components:
               items:
                 type: object
                 required:
+                - name
                 - type
                 - hosts
                 - serial
@@ -7497,6 +7500,8 @@ components:
                 - expiry
                 - status
                 properties:
+                  name:
+                    type: string
                   type:
                     type: string
                   hosts:
@@ -7583,6 +7588,7 @@ components:
               required:
               - name
               - type
+              - serial
               - product
               - issue
               - quantity
@@ -7593,6 +7599,8 @@ components:
                 name:
                   type: string
                 type:
+                  type: string
+                serial:
                   type: string
                 product:
                   type: object


### PR DESCRIPTION
### What type of PR is this?

Fix

### What this PR does?

1.) Add `name` field to Get License Response

<img width="705" alt="Screenshot 2025-04-25 at 3 08 47 PM" src="https://github.com/user-attachments/assets/8264ccb9-5041-488e-84a9-767a5e51f6c5" />

Mockup:

<img width="1219" alt="Screenshot 2025-04-25 at 3 10 39 PM" src="https://github.com/user-attachments/assets/0365fb3b-9cf8-45ba-b915-d566e321780d" />

2.) Add `serial` field to Verify License Response

<img width="693" alt="Screenshot 2025-04-25 at 3 09 09 PM" src="https://github.com/user-attachments/assets/5f897f74-2d7d-4236-91c6-05c7b04a9df6" />

Mockup:

<img width="1005" alt="Screenshot 2025-04-25 at 3 11 46 PM" src="https://github.com/user-attachments/assets/9bd47e2d-3fc7-4fbd-9b62-2a9d4942b0d7" />

### Test results (optional)

CI Passed
