### PR TITLE
Adjust the license desc and add a new opensearch api for fetching the single instance dashboard

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -10082,13 +10082,15 @@ components:
           type: string
         hardware:
           type: string
-          description: this field will be the serial number(s) of the host(s) that
+          description: >
+            this field will be the serial number(s) of the host(s) that
             the license is issued to. '*' means all hosts, genearlly, it's for trial
             license only. for the paid license, it will be the comma separated serial
             numbers of the hosts.
-          enum:
-          - "*"
-          - example-serial-number-1, example-serial-number-2, ...
+
+            examples:
+              - "*"
+              - example-serial-number-1, example-serial-number-2, ...
         date:
           type: string
           format: date-time

--- a/docs.yaml
+++ b/docs.yaml
@@ -1734,7 +1734,8 @@ paths:
                     code: 200
                     data:
                       licenses:
-                      - type: trial
+                      - name: example-license
+                        type: trial
                         hosts:
                         - example-node-0
                         serial: 1H2ZLG2
@@ -6501,6 +6502,65 @@ paths:
                   status:
                     type: string
                     example: internal server error
+  "/api/v1/datacenters/{dataCenter}/opensearch/instances/{instanceId}":
+    get:
+      operationId: getOpenSearchInstances
+      tags:
+      - OpenSearch
+      summary: Get OpenSearch instances dashboard
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/instanceId"
+      responses:
+        '200':
+          description: Get OpenSearch instances dashboard
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GetOpenSearchDashboardLinkResponse"
+              examples:
+                example:
+                  summary: Grafana instances dashboard link
+                  value:
+                    code: 200
+                    data:
+                      link: http://example-data-center/opensearch/waitingForCosToProvideTheActualPath/instance?var-TID=example-instance-id
+                      enabled: true
+                    msg: fetch top instance link successfully
+                    status: ok
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to get OpenSearch instances dashboard: internal
+                      server error'
+                  status:
+                    type: string
+                    example: internal server error
 components:
   parameters:
     dataCenter:
@@ -6511,6 +6571,14 @@ components:
         type: string
       description: The name of the data center to operate
       example: example-data-center
+    instanceId:
+      in: path
+      name: instanceId
+      required: true
+      schema:
+        type: string
+      description: The instance ID of the instance to operate
+      example: example-instance-id
     hostname:
       in: path
       name: hostname
@@ -6614,10 +6682,10 @@ components:
         items:
           type: string
           enum:
-          - cubeCOS
-          - cubeCMP
+          - CubeCOS
+          - CubeCMP
       description: The product of the host
-      example: cubeCOS
+      example: CubeCOS
     metricType:
       in: path
       name: metricType
@@ -7487,6 +7555,7 @@ components:
               items:
                 type: object
                 required:
+                - name
                 - type
                 - hosts
                 - serial
@@ -7497,6 +7566,8 @@ components:
                 - expiry
                 - status
                 properties:
+                  name:
+                    type: string
                   type:
                     type: string
                   hosts:
@@ -7516,21 +7587,7 @@ components:
                       feature:
                         type: string
                   issue:
-                    type: object
-                    required:
-                    - by
-                    - to
-                    - hardware
-                    - date
-                    properties:
-                      by:
-                        type: string
-                      to:
-                        type: string
-                      hardware:
-                        type: string
-                      date:
-                        type: string
+                    "$ref": "#/components/schemas/LicenseIssue"
                   quantity:
                     type: string
                   supportPlan:
@@ -7605,21 +7662,7 @@ components:
                     feature:
                       type: string
                 issue:
-                  type: object
-                  required:
-                  - by
-                  - to
-                  - hardware
-                  - date
-                  properties:
-                    by:
-                      type: string
-                    to:
-                      type: string
-                    hardware:
-                      type: string
-                    date:
-                      type: string
+                  "$ref": "#/components/schemas/LicenseIssue"
                 quantity:
                   type: string
                 supportPlan:
@@ -9551,6 +9594,30 @@ components:
           type: string
         status:
           type: string
+    GetOpenSearchDashboardLinkResponse:
+      type: object
+      required:
+      - code
+      - data
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+        data:
+          type: object
+          required:
+          - link
+          - enabled
+          properties:
+            link:
+              type: string
+            enabled:
+              type: boolean
+        msg:
+          type: string
+        status:
+          type: string
     MetricRank:
       type: object
       required:
@@ -9766,22 +9833,7 @@ components:
                 feature:
                   type: string
             issue:
-              type: object
-              required:
-              - by
-              - to
-              - hardware
-              - date
-              properties:
-                by:
-                  type: string
-                to:
-                  type: string
-                hardware:
-                  type: string
-                date:
-                  type: string
-                  format: date-time
+              "$ref": "#/components/schemas/LicenseIssue"
             quantity:
               type: string
             supportPlan:
@@ -10016,6 +10068,30 @@ components:
       - int
       - uint
       - bool
+    LicenseIssue:
+      type: object
+      required:
+      - by
+      - to
+      - hardware
+      - date
+      properties:
+        by:
+          type: string
+        to:
+          type: string
+        hardware:
+          type: string
+          description: this field will be the serial number(s) of the host(s) that
+            the license is issued to. '*' means all hosts, genearlly, it's for trial
+            license only. for the paid license, it will be the comma separated serial
+            numbers of the hosts.
+          enum:
+          - "*"
+          - example-serial-number-1, example-serial-number-2, ...
+        date:
+          type: string
+          format: date-time
     ListLicenseCurrentStatus:
       type: string
       enum:

--- a/docs.yaml
+++ b/docs.yaml
@@ -7549,6 +7549,9 @@ components:
           example: 200
         data:
           type: object
+          required: 
+          - licenses
+          - page
           properties:
             licenses:
               type: array


### PR DESCRIPTION
### What type of PR is this?

Feat and refactor

<br/>

### Which issue(s) this PR fixes?

Non

<br/>

### What this PR does?

<br/>

- License: change the enum product example to start with a capital

![Screenshot 2025-04-25 at 4 29 17 PM](https://github.com/user-attachments/assets/8e66abc9-05d6-4c4f-8637-a15baa449310)

<br/>

- License: add missed name field in the license related apis (api has returned the field, but missed doc)

![Screenshot 2025-04-25 at 4 48 10 PM](https://github.com/user-attachments/assets/0fa17858-4cfb-4c23-af03-973e1c25f012)

<br/>

- License: enrich the desc for license.hardware (to elaborate more for the hardware serial)

![Screenshot 2025-04-25 at 4 28 55 PM](https://github.com/user-attachments/assets/a50a8aa7-6492-47c3-a8df-b919c5e86542)

<br/>

- OpenSearch: add a GET api to fetch the opensearch link for single instanceId

![Screenshot 2025-04-25 at 4 29 59 PM](https://github.com/user-attachments/assets/12e46522-b88f-4b82-adf0-bd34e130ee8f)

<br/>
<br/>
<br/>

### Test results (optional)

1). make sure no error from the online swagger editor and CI

![Screenshot 2025-04-25 at 4 40 11 PM](https://github.com/user-attachments/assets/5ce94ab9-79ba-41f8-8675-cf5f7622bdf1)



