### PR TITLE
Replace the email sender's 'email' field with 'from' field

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -3198,7 +3198,7 @@ paths:
                         - host: email-smtp.example.mailserver.com
                           port: 587
                           username: ABBBBBBMJM56DCCCCJR
-                          email: noreply@example.com
+                          from: noreply@example.com
                           accessVerified: true
                           status:
                             current: ok
@@ -3304,7 +3304,7 @@ paths:
                   port: 587
                   username: ABBBBBBMJM56DCCCCJR
                   password: VBHWEEGEEEEEX0f5NLHDXLESxdZR
-                  email: noreply@example.com
+                  from: noreply@example.com
       responses:
         '201':
           description: Email sender created successfully
@@ -3351,7 +3351,7 @@ paths:
                     - host: email-smtp.example.mailserver.com
                       port: 587
                       username: example-user
-                      email: noreply@bigstack.co
+                      from: noreply@bigstack.co
                       accessVerified: true
                       status:
                         current: ok
@@ -3442,7 +3442,7 @@ paths:
         content:
           application/json:
             schema:
-              "$ref": "#/components/schemas/EmailSenderPutRequest"
+              "$ref": "#/components/schemas/EmailSenderPatchRequest"
             examples:
               example:
                 summary: Email Sender
@@ -3451,7 +3451,7 @@ paths:
                   port: 587
                   username: example-user
                   password: example-password
-                  email: noreply@bigstack.co
+                  from: noreply@bigstack.co
       responses:
         '200':
           description: Email sender updated successfully
@@ -7549,7 +7549,7 @@ components:
           example: 200
         data:
           type: object
-          required: 
+          required:
           - licenses
           - page
           properties:
@@ -8597,7 +8597,7 @@ components:
       - host
       - port
       - username
-      - email
+      - from
       - accessVerified
       - status
       properties:
@@ -8607,7 +8607,7 @@ components:
           type: integer
         username:
           type: string
-        email:
+        from:
           type: string
         accessVerified:
           type: boolean
@@ -8618,7 +8618,7 @@ components:
       required:
       - host
       - port
-      - email
+      - from
       - status
       properties:
         host:
@@ -8629,9 +8629,9 @@ components:
           type: string
         password:
           type: string
-        email:
+        from:
           type: string
-    EmailSenderPutRequest:
+    EmailSenderPatchRequest:
       type: object
       properties:
         host:
@@ -8642,7 +8642,7 @@ components:
           type: string
         password:
           type: string
-        email:
+        from:
           type: string
     TryEmailSender:
       type: object
@@ -10085,12 +10085,8 @@ components:
           type: string
         hardware:
           type: string
-          description: >
-            this field will be the serial number(s) of the host(s) that
-            the license is issued to. '*' means all hosts, genearlly, it's for trial
-            license only. for the paid license, it will be the comma separated serial
-            numbers of the hosts.
-
+          description: |
+            this field will be the serial number(s) of the host(s) that the license is issued to. '*' means all hosts, genearlly, it's for trial license only. for the paid license, it will be the comma separated serial numbers of the hosts.
             examples:
               - "*"
               - example-serial-number-1, example-serial-number-2, ...


### PR DESCRIPTION
### What type of PR is this?

Refactor and fix

<br/>

### Which issue(s) this PR fixes?

Non

<br/>

### What this PR does?

<br/>

Replace the email sender's **email** field with **from** field in the related apis below

![Screenshot 2025-04-28 at 4 05 19 PM](https://github.com/user-attachments/assets/45f2349b-832d-4e1a-90d0-4bcbc5d49d38)
![Screenshot 2025-04-28 at 4 07 18 PM](https://github.com/user-attachments/assets/c5529b79-5737-457d-90e2-7fbd2beaf1d5)
![Screenshot 2025-04-28 at 4 07 04 PM](https://github.com/user-attachments/assets/586f85e1-f308-4add-b103-8d7a3af82ac4)
![Screenshot 2025-04-28 at 4 06 46 PM](https://github.com/user-attachments/assets/f0518acc-d00c-46e5-a4fb-528746f42bd5)
![Screenshot 2025-04-28 at 4 06 29 PM](https://github.com/user-attachments/assets/d7cda2e4-eaee-405d-a687-e79fd097c81c)
![Screenshot 2025-04-28 at 4 06 12 PM](https://github.com/user-attachments/assets/18b307db-6695-473c-9f41-6cf4e14b0d62)
![Screenshot 2025-04-28 at 4 05 55 PM](https://github.com/user-attachments/assets/c0abce3b-71d3-4d63-8497-8f9b37ce6ee2)

<br/>

### Test results (optional)

1). make sure no error from the online swagger editor and CI

![Screenshot 2025-04-28 at 4 00 44 PM](https://github.com/user-attachments/assets/dfe6882b-eabe-455b-ada1-60b29771468a)



