### PR TITLE
Add a new GET API to fetch the list of license attachments

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -2003,6 +2003,81 @@ paths:
                   status:
                     type: string
                     example: internal server error
+  "/api/v1/datacenters/{dataCenter}/licenses/attachments":
+    get:
+      operationId: getLicenseAttachments
+      tags:
+      - Licenses
+      summary: Retrieve the list of license attachments
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/product"
+      - "$ref": "#/components/parameters/keyword"
+      - "$ref": "#/components/parameters/roles"
+      - "$ref": "#/components/parameters/listLicenseStatuses"
+      responses:
+        '200':
+          description: Retrieve the list of license attachments successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GetLicenseAttachmentsResponse"
+              examples:
+                example1:
+                  summary: License attachment list
+                  value:
+                    code: 200
+                    data:
+                    - serialNumber: To Be Filled By O.E.M.
+                      hostname: example-node-0
+                      role: control-converged
+                      product: CubeCOS
+                      status: valid
+                    - serialNumber: To Be Filled By O.E.M.
+                      hostname: example-node-1
+                      role: control-converged
+                      product: CubeCOS
+                      status: valid
+                    - serialNumber: To Be Filled By O.E.M.
+                      hostname: example-node-2
+                      role: control-converged
+                      product: CubeCOS
+                      status: unlicense
+                    msg: fetch license attachments successfully
+                    status: ok
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 401
+                  msg:
+                    type: string
+                    example: 'invalid_grant: Invalid user credentials'
+                  status:
+                    type: string
+                    example: unauthorized
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to fetch license attachments: internal server
+                      error'
+                  status:
+                    type: string
+                    example: internal server error
   "/api/v1/datacenters/{dataCenter}/metrics":
     get:
       operationId: getMetricsOverview
@@ -6673,6 +6748,17 @@ components:
           "$ref": "#/components/schemas/NodeLicenseCurrentStatus"
       description: The license status of the host
       example: valid
+    product:
+      in: query
+      name: product
+      required: false
+      schema:
+        type: string
+        enum:
+        - CubeCOS
+        - CubeCMP
+      description: The product of the host
+      example: CubeCOS
     products:
       in: query
       name: products
@@ -6684,7 +6770,7 @@ components:
           enum:
           - CubeCOS
           - CubeCMP
-      description: The product of the host
+      description: The products of the host
       example: CubeCOS
     metricType:
       in: path
@@ -7733,6 +7819,41 @@ components:
       properties:
         code:
           type: integer
+        msg:
+          type: string
+        status:
+          type: string
+    GetLicenseAttachmentsResponse:
+      type: object
+      required:
+      - code
+      - data
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+        data:
+          type: array
+          items:
+            type: object
+            required:
+            - serialNumber
+            - hostname
+            - role
+            - product
+            - status
+            properties:
+              serialNumber:
+                type: string
+              hostname:
+                type: string
+              role:
+                type: string
+              product:
+                type: string
+              status:
+                type: string
         msg:
           type: string
         status:

--- a/docs.yaml
+++ b/docs.yaml
@@ -2014,7 +2014,7 @@ paths:
       - "$ref": "#/components/parameters/product"
       - "$ref": "#/components/parameters/keyword"
       - "$ref": "#/components/parameters/roles"
-      - "$ref": "#/components/parameters/listLicenseStatuses"
+      - "$ref": "#/components/parameters/listLicenseAttachmentStatuses"
       responses:
         '200':
           description: Retrieve the list of license attachments successfully
@@ -6722,6 +6722,16 @@ components:
           "$ref": "#/components/schemas/ListLicenseCurrentStatus"
       description: The status of the host
       example: valid
+    listLicenseAttachmentStatuses:
+      in: query
+      name: statuses
+      required: false
+      schema:
+        type: array
+        items:
+          "$ref": "#/components/schemas/NodeLicenseCurrentStatus"
+      description: The status of the host
+      example: valid
     types:
       in: query
       name: types
@@ -7853,7 +7863,7 @@ components:
               product:
                 type: string
               status:
-                type: string
+                "$ref": "#/components/schemas/NodeLicenseCurrentStatus"
         msg:
           type: string
         status:


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cube-cos-api/issues/223

<br/>

### What this PR does?

📔 License attachment is an object to bind the relationship between license and node

- Add a new GET API to list the license attachments

- Support the filters below

  - Product: single selection - value range is `CubeCOS` and `CubeCMP`

  - Keyword: all fields of license attachments are involved in the search

  - Roles: multiple selection (4 cloud roles and 2 edge roles)

  - Statuses: multiple selection for attachment's license status (unlicense, valid, and expired)


<br/>

### Test results (optional)

1). make sure no error from the online swagger editor and CI

![Screenshot 2025-04-30 at 10 18 06 PM](https://github.com/user-attachments/assets/de179f74-8a61-4da9-a69c-bf3b49fde2b8)

<br/>

2). make sure the API doc has been updated accordingly

https://github.com/user-attachments/assets/c82d4310-5a87-43dd-b3b5-50cc9811411d

<br/>

3). make sure the mentioned apis can work properly

https://github.com/user-attachments/assets/ff47e4bc-c125-4f6a-b160-bbec0dce0212


