### PR TITLE
Add the severity, category, host, instanceId, and instanceName in the event rank api, then remove the query field

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -6623,31 +6623,31 @@ paths:
                   status:
                     type: string
                     example: internal server error
-  "/api/v1/datacenters/{dataCenter}/opensearch/instances/{instanceId}":
+  "/api/v1/datacenters/{dataCenter}/opensearch/requests/{requestId}":
     get:
-      operationId: getOpenSearchInstances
+      operationId: getOpenSearchRequestDashboard
       tags:
       - OpenSearch
-      summary: Get OpenSearch instances dashboard
+      summary: Get OpenSearch dashboard by request id
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
-      - "$ref": "#/components/parameters/instanceId"
+      - "$ref": "#/components/parameters/requestId"
       responses:
         '200':
-          description: Get OpenSearch instances dashboard
+          description: Get OpenSearch request id dashboard
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/GetOpenSearchDashboardLinkResponse"
               examples:
                 example:
-                  summary: Grafana instances dashboard link
+                  summary: Opensearch request id dashboard link
                   value:
                     code: 200
                     data:
-                      link: http://example-data-center/opensearch/waitingForCosToProvideTheActualPath/instance?var-TID=example-instance-id
+                      link: http://example-data-center/opensearch-dashboards/app/data-explorer/discover/#/view/req-aa95057d-aa8e-4c2c-af56-46ad614e6c33
                       enabled: true
-                    msg: fetch top instance link successfully
+                    msg: fetch opensearch dashboard link of request id successfully
                     status: ok
         '401':
           description: Unauthorized
@@ -6677,7 +6677,7 @@ paths:
                     example: 500
                   msg:
                     type: string
-                    example: 'failed to get OpenSearch instances dashboard: internal
+                    example: 'failed to get OpenSearch dashboard of request id: internal
                       server error'
                   status:
                     type: string
@@ -6700,6 +6700,14 @@ components:
         type: string
       description: The instance ID of the instance to operate
       example: example-instance-id
+    requestId:
+      in: path
+      name: requestId
+      required: true
+      schema:
+        type: string
+      description: The request id of the openstack instance operation
+      example: req-aa95057d-aa8e-4c2c-af56-46ad614e6c33
     hostname:
       in: path
       name: hostname

--- a/docs.yaml
+++ b/docs.yaml
@@ -868,19 +868,65 @@ paths:
                 "$ref": "#/components/schemas/GetRankedEventsResponse"
               examples:
                 example1:
-                  summary: Ranked events
+                  summary: Ranked system events
                   value:
                     code: 200
                     data:
                       events:
                       - id: NET00003I
+                        category: NET
+                        severity: I
                         percent: 98.2142
                         number: 440
-                        query: https://example-datat-center.host/api/v1/datacenters/example-data-center/events?type=system&id=NET00003I&start=2024-12-01T00:00:00Z&stop=2025-02-17T00:00:00Z&pageNum=1&pageSize=20
                       - id: NET00001I
+                        category: NET
+                        severity: I
                         percent: 1.7857
                         number: 8
-                        query: https://example-datat-center.host/api/v1/datacenters/example-data-center/events?type=system&id=NET00001I&start=2024-12-01T00:00:00Z&stop=2025-02-17T00:00:00Z&pageNum=1&pageSize=20
+                      limit:
+                        number: 25
+                        description: The top 2 event IDs with the highest proportion
+                    msg: fetch event rank successfully
+                    status: ok
+                example2:
+                  summary: Ranked host events
+                  value:
+                    code: 200
+                    data:
+                      events:
+                      - id: CPU00002W
+                        category: CPU
+                        host: example-host-0
+                        percent: 75
+                        number: 3
+                      - id: CPU00002W
+                        category: CPU
+                        host: example-host-1
+                        percent: 25
+                        number: 1
+                      limit:
+                        number: 25
+                        description: The top 2 event IDs with the highest proportion
+                    msg: fetch event rank successfully
+                    status: ok
+                example3:
+                  summary: Ranked instance events
+                  value:
+                    code: 200
+                    data:
+                      events:
+                      - id: CPU00007I
+                        category: CPU
+                        instanceId: 74ac7cb9-800a-430f-809e-d96f0ce3e9a2
+                        instanceName: example-vm-0
+                        percent: 75
+                        number: 3
+                      - id: CPU00007I
+                        category: CPU
+                        instanceId: e8a44a60-b79f-42f8-bab6-761b1734299a
+                        instanceName: example-vm-1
+                        percent: 25
+                        number: 1
                       limit:
                         number: 25
                         description: The top 2 event IDs with the highest proportion
@@ -7239,16 +7285,23 @@ components:
                 - id
                 - percent
                 - number
-                - query
                 properties:
                   id:
+                    type: string
+                  severity:
+                    type: string
+                  category:
+                    type: string
+                  host:
+                    type: string
+                  instanceId:
+                    type: string
+                  instanceName:
                     type: string
                   percent:
                     type: number
                   number:
                     type: integer
-                  query:
-                    type: string
             limit:
               type: object
               required:


### PR DESCRIPTION
### What type of PR is this?

Refactor

<br/>

### Which issue(s) this PR fixes?

#48 

<br/>

### What this PR does?

- Add the severity, category, host, instanceId, and instanceName in the event rank api

- Remove the query field in the event rank api (FE is not using it actually)

- The new fields `severity, category, host, instanceId, and instanceName` are not the required fields

- 🚢 Smuggling: Adjust Opensearch dashboard's GET api desc by the actual behavior from cos sdk

<br/>

### Test results (optional)

1). make sure the online swagger editor has no error for the adjusted api doc yaml

![Screenshot 2025-05-02 at 5 12 53 PM](https://github.com/user-attachments/assets/1393e5f6-67ea-4111-b5ff-afa7361c0aac)

<br/>

2). make sure the API doc has been updated accordingly

https://github.com/user-attachments/assets/47fbd40e-7cb3-4355-bb80-711ce5fd4dfe

<br/>

3). make sure the mentioned apis can work properly

https://github.com/user-attachments/assets/89b3c497-60dc-40e2-876a-c6468d05e471




