### PR TITLE
Add `isVirtualIpOwner` field in the node details and node list

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -3075,6 +3075,7 @@ paths:
                         ip: 10.10.10.10
                         managementIP: 10.10.10.10
                         storageIP: 10.10.10.10
+                        isVirtualIpOwner: true
                         license:
                           name: example-license
                           type: trial
@@ -3221,6 +3222,7 @@ paths:
                       ip: 10.10.10.10
                       managementIP: 10.10.10.10
                       storageIP: 10.10.10.10
+                      isVirtualIpOwner: true
                       license:
                         name: example-license
                         type: trial
@@ -6732,6 +6734,11 @@ paths:
                     type: string
                     example: internal server error
 components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
   parameters:
     dataCenter:
       in: path
@@ -10029,6 +10036,7 @@ components:
       - ip
       - managementIP
       - storageIP
+      - isVirtualIpOwner
       - license
       - status
       - cpuSpec
@@ -10058,6 +10066,8 @@ components:
           type: string
         storageIP:
           type: string
+        isVirtualIpOwner:
+          type: boolean
         license:
           type: object
           required:
@@ -10415,3 +10425,5 @@ components:
           - error
         isUpdating:
           type: boolean
+security:
+- BearerAuth: []


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

FE: https://github.com/bigstack-oss/cubecos/issues/183

BE: https://github.com/bigstack-oss/cubecos/issues/160

<br/>

### What this PR does?

Major:

  - Add `isVirtualIpOwner` field in the node details and node list

  - The info will be synced immediately when pcs vip is moving to the new host 

Minor:

  - Add securitySchemes to support token usage in the swagger page


<br/>

### Test results (already deployed on the 10.32.45.10)

1). make sure the corresponding api doc has been updated

https://github.com/user-attachments/assets/4e5eddbe-ba98-4cd9-bbb6-d237ab3f6ad1

<br/>

2). make sure the corresponding behavior work well

https://github.com/user-attachments/assets/211a0ff7-e36d-41f0-aa38-08c59908b9b8


