### PR TITLE
Add 7 APIs to operate the node block device and Ceph OSD

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -3245,22 +3245,6 @@ paths:
                           driver: tg3
                           state: DOWN
                           speed: NA/1000F
-                        blockDevices:
-                        - serial: '200264800526'
-                          device: nvme0n1
-                          type: SSD
-                          sizeMiB: 222110.7482
-                          availability: system
-                          status:
-                            current: ok
-                        - serial: '200598804038'
-                          device: nvme1n1
-                          type: SSD
-                          sizeMiB: 222110.7482
-                          availability: in-use
-                          status:
-                            current: warning
-                            description: status fetch timeout
                         ipmi:
                           isSupported: true
                           isConnected: false
@@ -3396,22 +3380,6 @@ paths:
                         driver: tg3
                         state: DOWN
                         speed: NA/1000F
-                      blockDevices:
-                      - serial: '200264800526'
-                        device: nvme0n1
-                        type: SSD
-                        sizeMiB: 222110.7482
-                        availability: system
-                        status:
-                          current: ok
-                      - serial: '200598804038'
-                        device: nvme1n1
-                        type: SSD
-                        sizeMiB: 222110.7482
-                        availability: in-use
-                        status:
-                          current: warning
-                          description: status fetch timeout
                       ipmi:
                         isSupported: true
                         isConnected: false
@@ -3730,6 +3698,455 @@ paths:
                   status:
                     type: string
                     example: internal server error
+  "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices":
+    get:
+      operationId: listNodeDevices
+      tags:
+      - Nodes
+      summary: Retrieve the node devices
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/nodeName"
+      - "$ref": "#/components/parameters/watch"
+      responses:
+        '200':
+          description: Retrieve the node devices successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ListNodeDevicesResponse"
+              examples:
+                example:
+                  summary: Node Devices
+                  value:
+                    code: 200
+                    data:
+                    - serial: 57T0A05UF5YE
+                      device: sda
+                      type: HDD
+                      class: hdd
+                      osd:
+                        pgs: 646
+                        reweight: 1
+                        daemons:
+                        - id: osd.0
+                          usagePercent: 21.9012
+                          status:
+                            current: up
+                            isProcessing: false
+                        - id: osd.1
+                          usagePercent: 17.4514
+                          status:
+                            current: up
+                            isProcessing: false
+                      sizeMiB: 533008.5754
+                      availability: in-use
+                      status:
+                        current: ok
+                        isPromotable: true
+                        isDemotable: false
+                        isProcessing: false
+                    - serial: 183222E1E59B
+                      device: sdb
+                      type: SSD
+                      class: ''
+                      osd:
+                        pgs: 0
+                        reweight: 0
+                        daemons: []
+                      sizeMiB: 426387.7868
+                      availability: system
+                      status:
+                        current: ok
+                        isPromotable: true
+                        isDemotable: false
+                        isProcessing: false
+                    - serial: 57P0A0EWF5YE
+                      device: sdc
+                      type: HDD
+                      class: hdd
+                      osd:
+                        pgs: 634
+                        reweight: 1
+                        daemons:
+                        - id: osd.2
+                          usagePercent: 15.748
+                          status:
+                            current: up
+                            isProcessing: false
+                        - id: osd.3
+                          usagePercent: 21.4815
+                          status:
+                            current: up
+                            isProcessing: false
+                      sizeMiB: 533008.5754
+                      availability: in-use
+                      status:
+                        current: ok
+                        isPromotable: true
+                        isDemotable: false
+                        isProcessing: false
+                    msg: fetch node devices successfully
+                    status: ok
+        '404':
+          description: Node not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 404
+                  msg:
+                    type: string
+                    example: node not found
+                  status:
+                    type: string
+                    example: not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to fetch setting: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+    post:
+      operationId: addNodeDevice
+      tags:
+      - Nodes
+      summary: Add a device to the node
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/nodeName"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/AddNodeDeviceRequest"
+            examples:
+              example:
+                summary: Add Node Device
+                value:
+                  device: sdb
+      responses:
+        '202':
+          description: the request to add node device is accepted successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/AddNodeDeviceResponse"
+        '404':
+          description: Node not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 404
+                  msg:
+                    type: string
+                    example: node not found
+                  status:
+                    type: string
+                    example: not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to add device: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices/{deviceName}":
+    delete:
+      operationId: removeNodeDevice
+      tags:
+      - Nodes
+      summary: Remove a device from the node
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/nodeName"
+      - "$ref": "#/components/parameters/deviceName"
+      responses:
+        '202':
+          description: the request to remove node device is accepted successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/RemoveNodeDeviceResponse"
+        '404':
+          description: Node or device not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 404
+                  msg:
+                    type: string
+                    example: node or device not found
+                  status:
+                    type: string
+                    example: not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to remove device: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+    patch:
+      operationId: updateNodeDevice
+      tags:
+      - Nodes
+      summary: Update a device on the node
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/nodeName"
+      - "$ref": "#/components/parameters/deviceName"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UpdateNodeDeviceRequest"
+            examples:
+              example1:
+                summary: Promote a device to SSD class
+                value:
+                  class: ssd
+              example2:
+                summary: Demote a device to HDD class
+                value:
+                  class: hdd
+      responses:
+        '202':
+          description: the request to update node device is accepted successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UpdateNodeDeviceResponse"
+        '404':
+          description: Node or device not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 404
+                  msg:
+                    type: string
+                    example: node or device not found
+                  status:
+                    type: string
+                    example: not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to update device: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/osds/{osdId}":
+    patch:
+      operationId: updateNodeOsd
+      tags:
+      - Nodes
+      summary: Update an OSD on the node
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/nodeName"
+      - "$ref": "#/components/parameters/osdId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UpdateNodeOsdRequest"
+            examples:
+              example:
+                summary: Reweight an OSD
+                value:
+                  reweight: 0.5
+      responses:
+        '202':
+          description: the request to update node OSD is accepted successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UpdateNodeOsdResponse"
+        '404':
+          description: Node or OSD not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 404
+                  msg:
+                    type: string
+                    example: node or osd not found
+                  status:
+                    type: string
+                    example: not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to update osd: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+    delete:
+      operationId: deleteNodeOsd
+      tags:
+      - Nodes
+      summary: Delete an OSD on the node
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/nodeName"
+      - "$ref": "#/components/parameters/osdId"
+      responses:
+        '202':
+          description: the request to delete node OSD is accepted successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/DeleteNodeOsdResponse"
+        '404':
+          description: Node or OSD not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 404
+                  msg:
+                    type: string
+                    example: node or osd not found
+                  status:
+                    type: string
+                    example: not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to delete osd: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/osds/{osdId}/restart":
+    post:
+      operationId: restartNodeOsd
+      tags:
+      - Nodes
+      summary: Restart an OSD on the node
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/nodeName"
+      - "$ref": "#/components/parameters/osdId"
+      responses:
+        '202':
+          description: the request to restart node OSD is accepted successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/RestartNodeOsdResponse"
+        '404':
+          description: Node or OSD not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 404
+                  msg:
+                    type: string
+                    example: node or osd not found
+                  status:
+                    type: string
+                    example: not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to restart osd: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
   "/api/v1/datacenters/{dataCenter}/settings":
     get:
       operationId: getSettings
@@ -3780,13 +4197,13 @@ paths:
                       slack:
                         channels:
                         - name: "#example-alert-channel-1"
-                          url: https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB
+                          url: https://hooks.slack.com/services/example-token
                           description: example alert channel 1
                           status:
                             current: ok
                             isUpdating: false
                         - name: "#example-alert-channel-2"
-                          url: https://hooks.slack.com/services/T9LMCCCCC/C08GQACCCCC/CCCCCCCSevAyxkM2dPYCCCCC
+                          url: https://hooks.slack.com/services/example-token
                           description: example alert channel 2
                           status:
                             current: ok
@@ -3876,8 +4293,8 @@ paths:
                 value:
                   host: email-smtp.example.mailserver.com
                   port: 587
-                  username: ABBBBBBMJM56DCCCCJR
-                  password: VBHWEEGEEEEEX0f5NLHDXLESxdZR
+                  username: example-user
+                  password: example-password
                   from: noreply@example.com
       responses:
         '201':
@@ -4333,7 +4750,7 @@ paths:
                 summary: Slack Channel
                 value:
                   name: "#example-alert-channel-1"
-                  url: https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB
+                  url: https://hooks.slack.com/services/example-token
                   description: example alert channel 1
       responses:
         '201':
@@ -4380,13 +4797,13 @@ paths:
                     data:
                       slackChannels:
                       - name: "#example-alert-channel-1"
-                        url: https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB
+                        url: https://hooks.slack.com/services/example-token
                         description: example alert channel 1
                         status:
                           current: ok
                           isUpdating: false
                       - name: "#example-alert-channel-2"
-                        url: https://hooks.slack.com/services/T9LMCCCCC/C08GQACCCCC/CCCCCCCSevAyxkM2dPYCCCCC
+                        url: https://hooks.slack.com/services/example-token
                         description: example alert channel 2
                         status:
                           current: ok
@@ -4470,7 +4887,7 @@ paths:
                 summary: Slack channel
                 value:
                   name: "#example-alert-channel-1"
-                  url: https://hooks.slack.com/services/T9LMBBBBB/B08GQABBBBB/BBBBBBBSevAyxkM2dPYBBBBB
+                  url: https://hooks.slack.com/services/example-token
                   description: example alert channel 1
       responses:
         '200':
@@ -4559,8 +4976,8 @@ paths:
                   value:
                     code: 201
                     data:
-                      token: eyJhbGciOiJSUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICIwdDdGdWlJZC1lbnhVUWRZWGVZalZ6Q0pQZFRWMmxaU0NZanRkQW01S3djIn0.eyJleHAiOjE3Mzg5NjA2NzYsImlhdCI6MTczODk1MzQ3NiwianRpIjoiZjZjZTJlMjMtYzgwNC00N2YxLWE0OWEtZjdlNWZlYTgyYThjIiwiaXNzIjoiaHR0cHM6Ly8xMC4zMi4xMC4xODA6MTA0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjpbIm1hc3Rlci1yZWFsbSIsImFjY291bnQiXSwic3ViIjoiMDY1OTVlMDAtZWIzOS00YWUxLTkzYjctZDMyNzg1MDdiZTUzIiwidHlwIjoiQmVhcmVyIiwiYXpwIjoidG9rZW4tY29ubmVjdCIsInNlc3Npb25fc3RhdGUiOiJlOTE0MWVhZC01MTQ1LTRjZmQtODhiZC00ZjYxYzI0MzA0NzAiLCJhY3IiOiIxIiwicmVhbG1fYWNjZXNzIjp7InJvbGVzIjpbImNyZWF0ZS1yZWFsbSIsImRlZmF1bHQtcm9sZXMtbWFzdGVyIiwib2ZmbGluZV9hY2Nlc3MiLCJhZG1pbiIsInVtYV9hdXRob3JpemF0aW9uIl19LCJyZXNvdXJjZV9hY2Nlc3MiOnsibWFzdGVyLXJlYWxtIjp7InJvbGVzIjpbInZpZXctaWRlbnRpdHktcHJvdmlkZXJzIiwidmlldy1yZWFsbSIsIm1hbmFnZS1pZGVudGl0eS1wcm92aWRlcnMiLCJpbXBlcnNvbmF0aW9uIiwiY3JlYXRlLWNsaWVudCIsIm1hbmFnZS11c2VycyIsInF1ZXJ5LXJlYWxtcyIsInZpZXctYXV0aG9yaXphdGlvbiIsInF1ZXJ5LWNsaWVudHMiLCJxdWVyeS11c2VycyIsIm1hbmFnZS1ldmVudHMiLCJtYW5hZ2UtcmVhbG0iLCJ2aWV3LWV2ZW50cyIsInZpZXctdXNlcnMiLCJ2aWV3LWNsaWVudHMiLCJtYW5hZ2UtYXV0aG9yaXphdGlvbiIsIm1hbmFnZS1jbGllbnRzIiwicXVlcnktZ3JvdXBzIl19LCJhY2NvdW50Ijp7InJvbGVzIjpbIm1hbmFnZS1hY2NvdW50IiwibWFuYWdlLWFjY291bnQtbGlua3MiLCJ2aWV3LXByb2ZpbGUiXX19LCJzY29wZSI6Im9wZW5pZCBlbWFpbCBwcm9maWxlIiwic2lkIjoiZTkxNDFlYWQtNTE0NS00Y2ZkLTg4YmQtNGY2MWMyNDMwNDcwIiwiZW1haWxfdmVyaWZpZWQiOmZhbHNlLCJwcmVmZXJyZWRfdXNlcm5hbWUiOiJhZG1pbiJ9.LkywGnG2BhQ90n-f3vJvX-frq1wRS6DAop5MUcCFb5FSuGvv3oP_byeiuHvh9rh06QWcwhpiTU_L_hOaUzMXF9spJjos8s2iOwK-4o46Ka_4Q2gnlitjd8ZG5wGfuqKRp0vb25RsBpNr6rxGFzOxxmULkjEXOGXbcrqQJBWIaWdRldYunLFRVErIpmH23w4KHKWSB5XkwqpkD9HnLH_PqbaunGpp2acgZ826JpevC8vhEhIg6fxXcDnCKhkw7nNvfs3rCC08Qci32WtzujeKH6js1ASRkKWOUxVkfIkzZ5Yg4Tfdb79_Tgy2iXLT3teeNTepmLsaftn2JzLn_6vHwg
-                      refresh: eyJhbGciOiJIUzI1NiIsInR5cCIgOiAiSldUIiwia2lkIiA6ICI1OGRkY2JhNC1hM2ZkLTQ2MTYtODgyYi1lMGY1ZjRlNzAyMTIifQ.eyJleHAiOjE3Mzg5NTUyNzYsImlhdCI6MTczODk1MzQ3NiwianRpIjoiNjkyZDkxMTAtMjExMy00NTU1LTgxMTctNWYxZTA2NzlmYmUxIiwiaXNzIjoiaHR0cHM6Ly8xMC4zMi4xMC4xODA6MTA0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwiYXVkIjoiaHR0cHM6Ly8xMC4zMi4xMC4xODA6MTA0NDMvYXV0aC9yZWFsbXMvbWFzdGVyIiwic3ViIjoiMDY1OTVlMDAtZWIzOS00YWUxLTkzYjctZDMyNzg1MDdiZTUzIiwidHlwIjoiUmVmcmVzaCIsImF6cCI6InRva2VuLWNvbm5lY3QiLCJzZXNzaW9uX3N0YXRlIjoiZTkxNDFlYWQtNTE0NS00Y2ZkLTg4YmQtNGY2MWMyNDMwNDcwIiwic2NvcGUiOiJvcGVuaWQgZW1haWwgcHJvZmlsZSIsInNpZCI6ImU5MTQxZWFkLTUxNDUtNGNmZC04OGJkLTRmNjFjMjQzMDQ3MCJ9._B9rU8TG_YSvwsri48bfne3RxFhc4Yq83bzR43nL4-c
+                      token: example-token
+                      refresh: example-refresh-token
                       expires:
                         access: 7200
                         refresh: 1800
@@ -7454,6 +7871,22 @@ components:
       schema:
         type: string
       example: example-node-0
+    deviceName:
+      in: path
+      name: deviceName
+      required: true
+      schema:
+        type: string
+      description: The device name to remove from the node
+      example: sdb
+    osdId:
+      in: path
+      name: osdId
+      required: true
+      schema:
+        type: string
+      description: The OSD ID to operate
+      example: osd.0
     instanceId:
       in: path
       name: instanceId
@@ -9568,6 +10001,14 @@ components:
         password:
           type: string
           description: Password for the node's IPMI interface
+    AddNodeDeviceRequest:
+      type: object
+      required:
+      - device
+      properties:
+        device:
+          type: string
+          description: The device path, e.g., sdc
     SetNodeIpmiSettingResponse:
       type: object
       required:
@@ -9600,6 +10041,228 @@ components:
         status:
           type: string
           example: ok
+    ListNodeDevicesResponse:
+      type: object
+      required:
+      - code
+      - data
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 200
+        data:
+          type: array
+          items:
+            type: object
+            required:
+            - serial
+            - device
+            - type
+            - class
+            - sizeMiB
+            - availability
+            - osd
+            - status
+            properties:
+              serial:
+                type: string
+              device:
+                type: string
+              class:
+                type: string
+                enum:
+                - ssd
+                - hdd
+              type:
+                type: string
+              sizeMiB:
+                type: number
+              availability:
+                type: string
+              osd:
+                type: object
+                required:
+                - pgs
+                - reweight
+                - daemons
+                properties:
+                  pgs:
+                    type: integer
+                  reweight:
+                    type: number
+                  daemons:
+                    type: array
+                    items:
+                      type: object
+                      required:
+                      - id
+                      - usagePercent
+                      - status
+                      properties:
+                        id:
+                          type: string
+                        usagePercent:
+                          type: number
+                        status:
+                          type: object
+                          required:
+                          - current
+                          - isProcessing
+                          properties:
+                            current:
+                              type: string
+                              enum:
+                              - up
+                              - down
+                              - warning
+                              - error
+                            isProcessing:
+                              type: boolean
+              status:
+                type: object
+                required:
+                - current
+                - description
+                - isPromotable
+                - isDemotable
+                - isProcessing
+                properties:
+                  current:
+                    type: string
+                    enum:
+                    - ok
+                    - warning
+                    - fail
+                  isPromotable:
+                    type: boolean
+                  isDemotable:
+                    type: boolean
+                  isProcessing:
+                    type: boolean
+                  description:
+                    type: string
+        msg:
+          type: string
+          example: list node devices successfully
+        status:
+          type: string
+          example: ok
+    AddNodeDeviceResponse:
+      type: object
+      required:
+      - code
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 202
+        msg:
+          type: string
+          example: the request to add node device is accepted successfully
+        status:
+          type: string
+          example: ok
+    UpdateNodeDeviceResponse:
+      type: object
+      required:
+      - code
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 202
+        msg:
+          type: string
+          example: the request to update node device is accepted successfully
+        status:
+          type: string
+          example: ok
+    RemoveNodeDeviceResponse:
+      type: object
+      required:
+      - code
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 202
+        msg:
+          type: string
+          example: the request to remove node device is accepted successfully
+        status:
+          type: string
+          example: ok
+    UpdateNodeOsdResponse:
+      type: object
+      required:
+      - code
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 202
+        msg:
+          type: string
+          example: the request to update node OSD is accepted successfully
+        status:
+          type: string
+          example: ok
+    RestartNodeOsdResponse:
+      type: object
+      required:
+      - code
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 202
+        msg:
+          type: string
+          example: the request to restart node OSD is accepted successfully
+        status:
+          type: string
+          example: ok
+    DeleteNodeOsdResponse:
+      type: object
+      required:
+      - code
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 202
+        msg:
+          type: string
+          example: the request to delete node OSD is accepted successfully
+        status:
+          type: string
+          example: ok
+    UpdateNodeDeviceRequest:
+      type: object
+      required:
+      - class
+      properties:
+        class:
+          type: string
+          enum:
+          - ssd
+          - hdd
+    UpdateNodeOsdRequest:
+      type: object
+      required:
+      - reweight
+      properties:
+        reweight:
+          type: number
+          description: The reweight value for the OSD, e.g., 0.5
     DisconnectNodeIpmiResponse:
       type: object
       required:
@@ -11232,7 +11895,6 @@ components:
       - status
       - cpuSpec
       - networkInterfaces
-      - blockDevices
       - ipmi
       - vcpu
       - memory
@@ -11347,42 +12009,6 @@ components:
                 type: string
               speed:
                 type: string
-        blockDevices:
-          type: array
-          items:
-            type: object
-            required:
-            - serial
-            - device
-            - type
-            - sizeMiB
-            - availability
-            - status
-            properties:
-              serial:
-                type: string
-              device:
-                type: string
-              type:
-                type: string
-              sizeMiB:
-                type: number
-              availability:
-                type: string
-              status:
-                type: object
-                required:
-                - current
-                - description
-                properties:
-                  current:
-                    type: string
-                    enum:
-                    - ok
-                    - warning
-                    - fail
-                  description:
-                    type: string
         ipmi:
           type: object
           required:

--- a/docs.yaml
+++ b/docs.yaml
@@ -4030,66 +4030,6 @@ paths:
                   status:
                     type: string
                     example: internal server error
-  "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices/{deviceName}/osds":
-    patch:
-      operationId: updateNodeDeviceOsds
-      tags:
-      - Nodes
-      summary: Update OSDs on the node device
-      parameters:
-      - "$ref": "#/components/parameters/dataCenter"
-      - "$ref": "#/components/parameters/nodeName"
-      - "$ref": "#/components/parameters/deviceName"
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              "$ref": "#/components/schemas/UpdateNodeOsdRequest"
-            examples:
-              example:
-                summary: Reweight an OSD
-                value:
-                  reweight: 0.75
-      responses:
-        '202':
-          description: the request to update node device OSDs is accepted successfully
-          content:
-            application/json:
-              schema:
-                "$ref": "#/components/schemas/UpdateNodeOsdResponse"
-        '404':
-          description: Node device not found
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  code:
-                    type: integer
-                    example: 404
-                  msg:
-                    type: string
-                    example: node device not found
-                  status:
-                    type: string
-                    example: not found
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  code:
-                    type: integer
-                    example: 500
-                  msg:
-                    type: string
-                    example: 'failed to update node device osds: internal server error'
-                  status:
-                    type: string
-                    example: internal server error
   "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/osds/{osdId}":
     patch:
       operationId: updateNodeOsd

--- a/docs.yaml
+++ b/docs.yaml
@@ -1344,6 +1344,7 @@ paths:
                       isRepairable: true
                       history:
                       - time: '2025-02-15T08:44:36+00:00'
+                        hostname: example-node-0
                         status: ng
                         error:
                           type: service down
@@ -1357,14 +1358,19 @@ paths:
                             ...} "
                           log: http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log
                       - time: '2025-02-15T08:49:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T08:54:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T08:59:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:04:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:09:36+00:00'
+                        hostname: example-node-0
                         status: ng
                         error:
                           type: service down
@@ -1378,14 +1384,19 @@ paths:
                             ...} "
                           log: http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log
                       - time: '2025-02-15T09:14:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:19:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:24:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:29:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:34:36+00:00'
+                        hostname: example-node-0
                         status: ng
                         error:
                           type: service down
@@ -1399,8 +1410,10 @@ paths:
                             ...} "
                           log: http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log
                       - time: '2025-02-15T09:39:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:44:36+00:00'
+                        hostname: example-node-0
                         status: ok
                     - category: cloud computing
                       service: compute
@@ -1408,6 +1421,7 @@ paths:
                       isRepairable: true
                       history:
                       - time: '2025-02-15T08:44:36+00:00'
+                        hostname: example-node-0
                         status: ng
                         error:
                           type: service down
@@ -1421,14 +1435,19 @@ paths:
                             ...} "
                           log: http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log
                       - time: '2025-02-15T08:49:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T08:54:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T08:59:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:04:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:09:36+00:00'
+                        hostname: example-node-0
                         status: ng
                         error:
                           type: service down
@@ -1442,14 +1461,19 @@ paths:
                             ...} "
                           log: http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log
                       - time: '2025-02-15T09:14:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:19:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:24:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:29:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:34:36+00:00'
+                        hostname: example-node-0
                         status: ng
                         error:
                           type: service down
@@ -1463,8 +1487,10 @@ paths:
                             ...} "
                           log: http://{dataCenter}:8888/log/nova/example-data-center-20250205113459-b3gc.log
                       - time: '2025-02-15T09:39:36+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-15T09:44:36+00:00'
+                        hostname: example-node-0
                         status: ok
                     msg: fetch health successfully
                     status: ok
@@ -1621,6 +1647,16 @@ paths:
       - "$ref": "#/components/parameters/start"
       - "$ref": "#/components/parameters/stop"
       - "$ref": "#/components/parameters/watch"
+      - in: query
+        name: aggregate
+        required: false
+        schema:
+          type: boolean
+          default: false
+        description: If true, the health history will be aggregated by time and status(fixing
+          related status > ng related status > ok related status), otherwise it will
+          return the raw history data.
+        example: 'false'
       responses:
         '200':
           description: Retrieve the health history of module successfully
@@ -1640,10 +1676,13 @@ paths:
                       isRepairable: true
                       history:
                       - time: '2025-02-01T03:00:00+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-01T02:55:00+00:00'
+                        hostname: example-node-0
                         status: ok
                       - time: '2025-02-01T02:50:00+00:00'
+                        hostname: example-node-0
                         status: ng
                         error:
                           type: service down
@@ -1656,6 +1695,7 @@ paths:
                           details: "{ ... best effort error summary / direction ...}"
                           log: http://datacenter1:8888/log/nova/example-data-center-20250205113459-b3gc.log
                       - time: '2025-02-01T02:45:00+00:00'
+                        hostname: example-node-0
                         status: ok
                       status:
                         current: ok
@@ -8770,15 +8810,20 @@ components:
                   type: object
                   required:
                   - time
+                  - hostname
                   - status
                   properties:
                     time:
                       type: string
                       format: date-time
+                    hostname:
+                      type: string
+                      example: example-node-0
                     status:
                       type: string
                       enum:
                       - ok
+                      - fixing
                       - ng
                     error:
                       type: object
@@ -8874,10 +8919,14 @@ components:
                   time:
                     type: string
                     format: date-time
+                  hostname:
+                    type: string
+                    example: example-node-0
                   status:
                     type: string
                     enum:
                     - ok
+                    - fixing
                     - ng
                   error:
                     type: object

--- a/docs.yaml
+++ b/docs.yaml
@@ -3764,7 +3764,7 @@ paths:
                     - serial: 57T0A05UF5YE
                       device: sda
                       type: HDD
-                      class: hdd
+                      class: HDD
                       osd:
                         pgs: 646
                         reweight: 1
@@ -3804,7 +3804,7 @@ paths:
                     - serial: 57P0A0EWF5YE
                       device: sdc
                       type: HDD
-                      class: hdd
+                      class: HDD
                       osd:
                         pgs: 634
                         reweight: 1
@@ -3829,7 +3829,7 @@ paths:
                     msg: fetch node devices successfully
                     status: ok
         '404':
-          description: Node not found
+          description: Node device not found
           content:
             application/json:
               schema:
@@ -3840,7 +3840,7 @@ paths:
                     example: 404
                   msg:
                     type: string
-                    example: node not found
+                    example: node device not found
                   status:
                     type: string
                     example: not found
@@ -3986,11 +3986,11 @@ paths:
               example1:
                 summary: Promote a device to SSD class
                 value:
-                  class: ssd
+                  class: SSD
               example2:
                 summary: Demote a device to HDD class
                 value:
-                  class: hdd
+                  class: HDD
       responses:
         '202':
           description: the request to update node device is accepted successfully
@@ -4030,6 +4030,66 @@ paths:
                   status:
                     type: string
                     example: internal server error
+  "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/devices/{deviceName}/osds":
+    patch:
+      operationId: updateNodeDeviceOsds
+      tags:
+      - Nodes
+      summary: Update OSDs on the node device
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/nodeName"
+      - "$ref": "#/components/parameters/deviceName"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/UpdateNodeOsdRequest"
+            examples:
+              example:
+                summary: Reweight an OSD
+                value:
+                  reweight: 0.75
+      responses:
+        '202':
+          description: the request to update node device OSDs is accepted successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/UpdateNodeOsdResponse"
+        '404':
+          description: Node device not found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 404
+                  msg:
+                    type: string
+                    example: node device not found
+                  status:
+                    type: string
+                    example: not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to update node device osds: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
   "/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/osds/{osdId}":
     patch:
       operationId: updateNodeOsd
@@ -4050,7 +4110,7 @@ paths:
               example:
                 summary: Reweight an OSD
                 value:
-                  reweight: 0.5
+                  reweight: 0.75
       responses:
         '202':
           description: the request to update node OSD is accepted successfully
@@ -10120,16 +10180,17 @@ components:
               device:
                 type: string
               class:
-                type: string
-                enum:
-                - ssd
-                - hdd
+                "$ref": "#/components/schemas/DeviceType"
               type:
                 type: string
               sizeMiB:
                 type: number
               availability:
                 type: string
+                enum:
+                - available
+                - in-use
+                - system
               osd:
                 type: object
                 required:
@@ -10300,10 +10361,7 @@ components:
       - class
       properties:
         class:
-          type: string
-          enum:
-          - ssd
-          - hdd
+          "$ref": "#/components/schemas/DeviceType"
     UpdateNodeOsdRequest:
       type: object
       required:
@@ -10311,7 +10369,8 @@ components:
       properties:
         reweight:
           type: number
-          description: The reweight value for the OSD, e.g., 0.5
+          description: The reweight value for the OSD. It's only allow to have two
+            decimal places with a range of 0.0 to 1.0, for example, 0.5 or 0.75.
     DisconnectNodeIpmiResponse:
       type: object
       required:
@@ -12313,5 +12372,10 @@ components:
           - error
         isUpdating:
           type: boolean
+    DeviceType:
+      type: string
+      enum:
+      - SSD
+      - HDD
 security:
 - BearerAuth: []


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>
<br/>

### Which issue(s) this PR fixes?

1). major:

- https://github.com/bigstack-oss/cubecos/issues/158

- https://github.com/bigstack-oss/cubecos/issues/209

- https://github.com/bigstack-oss/cubecos/issues/210

- https://github.com/bigstack-oss/cubecos/issues/211

- https://github.com/bigstack-oss/cubecos/issues/212

- https://github.com/bigstack-oss/cubecos/issues/213

- https://github.com/bigstack-oss/cubecos/issues/214

<br/>

2). minor:

- https://github.com/bigstack-oss/cubecos/issues/221

- https://github.com/bigstack-oss/cubecos/issues/220

<br/>
<br/>

### What this PR does?

1). major:

- Add 7 APIs for block device and OSD operations (list, add, remove, restart, reweight, promote/demote, and so on ...)

- Remove `blockDevices` field from the `node list api` and `node get details api` (as discussed with @steven-chiu-bigstack , consider to bring the better performance and experience to user, we separate it out from the node details because the block device list would take so long from Ceph)

- Add corresponding api docs for the APIs above

<br/>

2). minor: health GET /healths/services/{service}/modules/{module}

- Adding the `hostname` in the time serials history

- Adding all statuses back to time serials history (in the M1, we only parse the `ok` and `ng` records)

- Support `aggregate` param to control the different health history/details response

  - true: time will be aggregated by every 10 mins and the status will be aggregated by the priority Fixing > NG > Ok

  - false: no any aggregation for either time and status

<br/>
<br/>

### Test results (optional)

1). make sure the no any doc errors from Swagger online editor

<img width="1909" height="957" alt="Screenshot 2025-07-16 at 8 43 40 PM" src="https://github.com/user-attachments/assets/02578a51-15f6-4399-9faf-9b44b2354a27" />

<br/>
<br/>
<br/>

2). make sure the api docs have been updated accordingly

could check and direct interact with https://10.32.45.10/api/v1/datacenters/control/apidocs/index.html#