### PR TITLE
Turn to use 'application/octet-stream' for streaming image upload between client and server disk

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -8327,13 +8327,14 @@ paths:
         description: Whether the source image comes from another hypervisor
       - name: visibility
         in: query
-        required: true
+        required: false
         schema:
           type: string
           enum:
           - private
           - public
-        description: Visibility setting for the image
+        description: Visibility setting for the image(only required when sourceFromAnotherHypervisor
+          is false).
       requestBody:
         description: for example, in the CURL, the image binary should be set by the
           '--data-binary' option like '--data-binary @/path/to/your-image'.

--- a/docs.yaml
+++ b/docs.yaml
@@ -8271,65 +8271,78 @@ paths:
       summary: Import an image
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
+      - name: file
+        in: query
+        required: true
+        schema:
+          type: string
+        description: Name of the file to store
+      - name: name
+        in: query
+        required: true
+        schema:
+          type: string
+        description: Human-readable name of the image
+      - name: os
+        in: query
+        required: true
+        schema:
+          type: string
+          enum:
+          - CentOS
+          - Fedora
+          - Ubuntu
+          - Debian
+          - Windows
+          - Rocky
+          - FreeBSD
+          - CoreOS
+          - Arch
+          - Others
+        description: Operating system of the image
+      - name: destination
+        in: query
+        required: true
+        schema:
+          type: string
+        description: Target storage destination. Refer the GET /images/materials endpoint
+          for available options
+      - name: domain
+        in: query
+        required: true
+        schema:
+          type: string
+        description: Domain name for the project
+      - name: project
+        in: query
+        required: true
+        schema:
+          type: string
+        description: Project name or ID
+      - name: sourceFromAnotherHypervisor
+        in: query
+        required: true
+        schema:
+          type: boolean
+        description: Whether the source image comes from another hypervisor
+      - name: visibility
+        in: query
+        required: true
+        schema:
+          type: string
+          enum:
+          - private
+          - public
+        description: Visibility setting for the image
       requestBody:
+        description: for example, in the CURL, the image binary should be set by the
+          '--data-binary' option like '--data-binary @/path/to/your-image'.
         required: true
         content:
-          multipart/form-data:
+          application/octet-stream:
             schema:
-              type: object
-              required:
-              - image
-              - file
-              - name
-              - os
-              - destination
-              - domain
-              - project
-              - sourceFromAnotherHypervisor
-              - visibility
-              properties:
-                image:
-                  type: string
-                  format: binary
-                  description: The image file to import
-                file:
-                  type: string
-                  description: The file name of the image to import
-                name:
-                  type: string
-                  description: The name of the image to import
-                os:
-                  type: string
-                  description: The OS of the image to import
-                  enum:
-                  - CentOS
-                  - Fedora
-                  - Ubuntu
-                  - Debian
-                  - Windows
-                  - Rocky
-                  - FreeBSD
-                  - CoreOS
-                  - Arch
-                  - Others
-                destination:
-                  type: string
-                  description: The destination of the image to import
-                domain:
-                  type: string
-                  description: The domain of the image to import
-                project:
-                  type: string
-                  description: The project of the image to import
-                sourceFromAnotherHypervisor:
-                  type: boolean
-                  description: Whether the image is from another hypervisor
-                visibility:
-                  type: string
-                  description: The visibility of the image to import
-                  enum:
-                  - public
-                  - private
+              type: string
+              format: binary
       responses:
         '202':
           description: Image import accepted and under processing


### PR DESCRIPTION
### What type of PR is this?

Refactor

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/240

<br/>

### What this PR does?

Turn to use 'application/octet-stream' for streaming image upload between client and server disk

Reasons to use 'application/octet-stream'

- to prevent the server OOM while uploading large file

- the pervious way - `multipart/form-data` is pretty hard to stream the binary between client and server disk.

- 'application/octet-stream' is more often to deal with the large file (scp is using the same way)

- 'application/octet-stream' is more easier to monitor the upload progress

<br/>

The way to interact with it by CURL is like

- put the attributes in the `query parameter`

- use `Content-Type: application/octet-stream`

- set the image path by `--data-binary "@ ..."`

```bash
curl -k -X POST "https://10.32.45.10/api/v1/datacenters/control/images?file=amphora-x64-haproxy-yoga.qcow2&name=amphora&os=Ubuntu&destination=CubeStorage&domain=Default&project=admin&sourceFromAnotherHypervisor=false&visibility=private" \
     -H "Authorization: Bearer ${TOKEN}" \
     -H "Content-Type: application/octet-stream" \
     --data-binary "@/Users/bjergsen.zhu/Downloads/amphora-x64-haproxy-yoga.qcow2"
```


<br/>

### Test results (optional)

1). make sure no any errors from online swagger editor

<img width="1718" height="993" alt="Screenshot 2025-08-01 at 1 51 23 AM" src="https://github.com/user-attachments/assets/82224c31-9bfe-4a3d-926b-431fa32180d0" />

<br/>
<br/>
<br/>

2). make sure the API doc has been updated

https://github.com/user-attachments/assets/bba14e62-c0c5-443a-9266-43aa9edd5e41


