### PR TITLE
Add 2 GET APIs for volume list and download csv file, also add a POST API to convert image to volume 

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -6691,7 +6691,9 @@ paths:
                   summary: Trigger script verification result
                   value:
                     code: 200
-                    data: Hello
+                    data: 'Hello
+
+                      '
                     msg: trigger script verified successfully
                     status: ok
         '400':
@@ -12581,11 +12583,15 @@ components:
                       current:
                         type: string
                         enum:
+                        - queued
+                        - saving
                         - uploading
                         - importing
                         - active
-                        - deleting
-                        - error
+                        - deactivated
+                        - killed
+                        - deleted
+                        - pending_delete
                       isProcessing:
                         type: boolean
                       processPercent:
@@ -12662,9 +12668,15 @@ components:
                         enum:
                         - uploading
                         - importing
-                        - active
+                        - available
+                        - creating
+                        - attaching
+                        - detaching
                         - deleting
-                        - error
+                        - reserved
+                        - maintenance
+                        - backing-up
+                        - restoring-backup
                       isProcessing:
                         type: boolean
                       processPercent:

--- a/docs.yaml
+++ b/docs.yaml
@@ -6691,7 +6691,7 @@ paths:
                   summary: Trigger script verification result
                   value:
                     code: 200
-                    data: Hello\n
+                    data: Hello
                     msg: trigger script verified successfully
                     status: ok
         '400':
@@ -6706,7 +6706,7 @@ paths:
                     example: 400
                   data:
                     type: string
-                    example: ""
+                    example: ''
                   msg:
                     type: string
                     example: invalid script content
@@ -6725,7 +6725,7 @@ paths:
                     example: 401
                   data:
                     type: string
-                    example: ""
+                    example: ''
                   msg:
                     type: string
                     example: 'invalid_grant: Invalid user credentials'
@@ -6744,7 +6744,7 @@ paths:
                     example: 500
                   data:
                     type: string
-                    example: ""
+                    example: ''
                   msg:
                     type: string
                     example: 'failed to verify trigger script: internal server error'
@@ -8233,29 +8233,35 @@ paths:
                   value:
                     code: 200
                     data:
-                    - id: 763655de-1cfc-45d4-b67c-5579ea43a6e1
-                      name: example image 0
-                      os: ubuntu
-                      destination: CubeStorage
-                      domainName: default
-                      projectName: admin
-                      visibilityType: public
-                      createdAt: '2025-07-27T13:08:53+08:00'
-                      status:
-                        current: active
-                        isProcessing: false
-                    - id: a5218f3c-47df-4ba2-ad41-5e9a50816e6c
-                      name: example image 2
-                      os: ubuntu
-                      destination: CubeStorage
-                      domainName: default
-                      projectName: admin
-                      visibilityType: public
-                      createdAt: '2025-07-29T13:08:53+08:00'
-                      status:
-                        current: importing
-                        isProcessing: true
-                        processPercent: 50.98
+                      images:
+                      - id: 763655de-1cfc-45d4-b67c-5579ea43a6e1
+                        name: example image 0
+                        os: Ubuntu
+                        destination: CubeStorage
+                        domainName: default
+                        projectName: admin
+                        visibilityType: public
+                        createdAt: '2025-07-27T13:08:53+08:00'
+                        status:
+                          current: active
+                          isProcessing: false
+                      - id: a5218f3c-47df-4ba2-ad41-5e9a50816e6c
+                        name: example image 1
+                        os: Ubuntu
+                        destination: CubeStorage
+                        domainName: default
+                        projectName: admin
+                        visibilityType: private
+                        createdAt: '2025-07-29T13:08:53+08:00'
+                        status:
+                          current: importing
+                          isProcessing: true
+                          processPercent: 50.98
+                      page:
+                        total: 1
+                        number: 1
+                        size: 2
+                        totalItemCount: 2
                     msg: fetch image list successfully
                     status: ok
         '500':
@@ -8281,73 +8287,18 @@ paths:
       summary: Import an image
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
-      - name: file
-        in: query
-        required: true
-        schema:
-          type: string
-        description: Name of the file to store
-      - name: name
-        in: query
-        required: true
-        schema:
-          type: string
-        description: Human-readable name of the image
-      - name: os
-        in: query
-        required: true
-        schema:
-          type: string
-          enum:
-          - CentOS
-          - Fedora
-          - Ubuntu
-          - Debian
-          - Windows
-          - Rocky
-          - FreeBSD
-          - CoreOS
-          - Arch
-          - Others
-        description: Operating system of the image
-      - name: destination
-        in: query
-        required: true
-        schema:
-          type: string
-        description: Target storage destination. Refer the GET /images/materials endpoint
-          for available options
-      - name: domain
-        in: query
-        required: true
-        schema:
-          type: string
-        description: Domain name for the project
-      - name: project
-        in: query
-        required: true
-        schema:
-          type: string
-        description: Project name or ID
-      - name: sourceFromAnotherHypervisor
-        in: query
-        required: true
-        schema:
-          type: boolean
-        description: Whether the source image comes from another hypervisor
-      - name: visibility
-        in: query
-        required: false
-        schema:
-          type: string
-          enum:
-          - private
-          - public
-        description: Visibility setting for the image(only required when sourceFromAnotherHypervisor
-          is false).
+      - "$ref": "#/components/parameters/file"
+      - "$ref": "#/components/parameters/name"
+      - "$ref": "#/components/parameters/os"
+      - "$ref": "#/components/parameters/destination"
+      - "$ref": "#/components/parameters/domain"
+      - "$ref": "#/components/parameters/project"
+      - "$ref": "#/components/parameters/sourceFromAnotherHypervisor"
+      - "$ref": "#/components/parameters/visibility"
       requestBody:
         description: for example, in the CURL, the image binary should be set by the
-          '--data-binary' option like '--data-binary @/path/to/your-image'.
+          '--data-binary' option like '--data-binary @/path/to/small-image' or '-T
+          /path/to/large-image'.
         required: true
         content:
           application/octet-stream:
@@ -8391,6 +8342,215 @@ paths:
                   status:
                     type: string
                     example: internal server error
+  "/api/v1/datacenters/{dataCenter}/images.csv":
+    get:
+      operationId: listImagesAsCsv
+      tags:
+      - Images
+      summary: List images as CSV
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/pageSize"
+      - "$ref": "#/components/parameters/pageNum"
+      - "$ref": "#/components/parameters/keyword"
+      responses:
+        '200':
+          description: List image as CSV format successfully
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to list images as CSV: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/volumes":
+    get:
+      operationId: listVolumes
+      tags:
+      - Volumes
+      summary: List volumes
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/project"
+      - "$ref": "#/components/parameters/watch"
+      - "$ref": "#/components/parameters/pageSize"
+      - "$ref": "#/components/parameters/pageNum"
+      - "$ref": "#/components/parameters/keyword"
+      responses:
+        '200':
+          description: List volumes successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ListVolumesResponse"
+              examples:
+                example:
+                  summary: Volume list
+                  value:
+                    code: 200
+                    data:
+                      volumes:
+                      - id: 763655de-1cfc-45d4-b67c-5579ea43a6e1
+                        name: example volume 0
+                        type: CubeStorage
+                        diskTag: os disk
+                        attachedTo: "/dev/sda on example-vm-0"
+                        bootable: true
+                        shared: false
+                        sizeMiB: 40960
+                        createdAt: '2025-07-27T13:08:53+08:00'
+                        status:
+                          current: active
+                          isProcessing: false
+                      - id: 888955de-4ghu-5325-1734-5579ea43a6e2
+                        name: example volume 1
+                        type: CubeStorage
+                        diskTag: data disk
+                        attachedTo: ''
+                        bootable: false
+                        shared: false
+                        sizeMiB: 20480
+                        createdAt: '2025-07-27T13:08:53+08:00'
+                        status:
+                          current: importing
+                          isProcessing: true
+                          processPercent: 50.98
+                      page:
+                        total: 1
+                        number: 1
+                        size: 2
+                        totalItemCount: 2
+                    msg: fetch volume list successfully
+                    status: ok
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to list volumes: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/volumes.csv":
+    get:
+      operationId: listVolumesAsCsv
+      tags:
+      - Volumes
+      summary: List volumes as CSV
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/project"
+      - "$ref": "#/components/parameters/pageSize"
+      - "$ref": "#/components/parameters/pageNum"
+      - "$ref": "#/components/parameters/keyword"
+      responses:
+        '200':
+          description: List volume as CSV format successfully
+          content:
+            text/csv:
+              schema:
+                type: string
+                format: binary
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to list volumes as CSV: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/volumes/images":
+    post:
+      operationId: convertImageToVolume
+      tags:
+      - Volumes
+      summary: Import a volume from an image
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/file"
+      - "$ref": "#/components/parameters/name"
+      - "$ref": "#/components/parameters/os"
+      - "$ref": "#/components/parameters/destination"
+      - "$ref": "#/components/parameters/domain"
+      - "$ref": "#/components/parameters/project"
+      - "$ref": "#/components/parameters/sourceFromAnotherHypervisor"
+      - "$ref": "#/components/parameters/visibility"
+      requestBody:
+        description: for example, in the CURL, the image binary should be set by the
+          '--data-binary' option like '--data-binary @/path/to/small-image' or '-T
+          /path/to/large-image'.
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '202':
+          description: Image volume convertion accepted and under processing
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - code
+                - msg
+                - status
+                properties:
+                  code:
+                    type: integer
+                    example: 202
+                  msg:
+                    type: string
+                    example: image volume convertion accepted and under processing
+                  status:
+                    type: string
+                    example: accepted
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to convert image to volume: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
 components:
   securitySchemes:
     BearerAuth:
@@ -8414,6 +8574,14 @@ components:
       schema:
         type: string
       example: example-node-0
+    project:
+      in: query
+      name: project
+      required: true
+      schema:
+        type: string
+      description: The project name to filter volumes
+      example: example-project
     deviceName:
       in: path
       name: deviceName
@@ -8652,6 +8820,71 @@ components:
         type: string
       description: The name of the trigger to operate
       example: Administrative Level Notification
+    file:
+      name: file
+      in: query
+      required: true
+      schema:
+        type: string
+      description: Name of the file to store
+    name:
+      name: name
+      in: query
+      required: true
+      schema:
+        type: string
+      description: Human-readable name of the image
+    os:
+      name: os
+      in: query
+      required: true
+      schema:
+        type: string
+        enum:
+        - CentOS
+        - Fedora
+        - Ubuntu
+        - Debian
+        - Windows
+        - Rocky
+        - FreeBSD
+        - CoreOS
+        - Arch
+        - Others
+      description: Operating system of the image
+    destination:
+      name: destination
+      in: query
+      required: true
+      schema:
+        type: string
+      description: Target storage destination. Refer the GET /images/materials endpoint
+        for available options
+    domain:
+      name: domain
+      in: query
+      required: true
+      schema:
+        type: string
+      description: Domain name for the project
+    sourceFromAnotherHypervisor:
+      name: sourceFromAnotherHypervisor
+      in: query
+      required: true
+      schema:
+        type: boolean
+      description: Whether the source image comes from another hypervisor
+    visibility:
+      name: visibility
+      in: query
+      required: false
+      schema:
+        type: string
+        enum:
+        - private
+        - public
+      description: Visibility setting for the image(only required when sourceFromAnotherHypervisor
+        is false).
   schemas:
     GetMeResponse:
       type: object
@@ -11902,7 +12135,9 @@ components:
           example: 200
         data:
           type: string
-          example: Hello\n
+          example: 'Hello
+
+            '
         msg:
           type: string
           example: trigger script verified successfully
@@ -12292,46 +12527,153 @@ components:
           type: integer
           example: 200
         data:
-          type: array
-          items:
-            type: object
-            required:
-            - id
-            - name
-            - os
-            - destination
-            - domain
-            - project
-            - visibility
-            - sizeMiB
-            - createdAt
-            - status
-            properties:
-              id:
-                type: string
-              name:
-                type: string
-              os:
-                type: string
-              destination:
-                type: string
-              domain:
-                type: string
-              project:
-                type: string
-              visibility:
-                type: string
-                enum:
-                - public
-                - private
-                - shared
-                - community
-                - unknown
-              createdAt:
-                type: string
+          type: object
+          required:
+          - images
+          - page
+          properties:
+            images:
+              type: array
+              items:
+                type: object
+                required:
+                - id
+                - name
+                - os
+                - destination
+                - domain
+                - project
+                - visibility
+                - sizeMiB
+                - createdAt
+                - status
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  os:
+                    type: string
+                  destination:
+                    type: string
+                  domain:
+                    type: string
+                  project:
+                    type: string
+                  visibility:
+                    type: string
+                    enum:
+                    - public
+                    - private
+                    - shared
+                    - community
+                    - unknown
+                  createdAt:
+                    type: string
+                  sizeMiB:
+                    type: number
+                  status:
+                    type: object
+                    required:
+                    - current
+                    - isProcessing
+                    properties:
+                      current:
+                        type: string
+                        enum:
+                        - uploading
+                        - importing
+                        - active
+                        - deleting
+                        - error
+                      isProcessing:
+                        type: boolean
+                      processPercent:
+                        type: number
+            page:
+              "$ref": "#/components/schemas/Page"
         msg:
           type: string
           example: images retrieved successfully
+        status:
+          type: string
+          example: ok
+    ListVolumesResponse:
+      type: object
+      required:
+      - code
+      - data
+      - msg
+      - status
+      properties:
+        code:
+          type: integer
+          example: 200
+        data:
+          type: object
+          required:
+          - volumes
+          - page
+          properties:
+            volumes:
+              type: array
+              items:
+                type: object
+                required:
+                - id
+                - name
+                - type
+                - diskTag
+                - attachedTo
+                - bootable
+                - shared
+                - createdAt
+                - status
+                properties:
+                  id:
+                    type: string
+                  name:
+                    type: string
+                  type:
+                    type: string
+                  diskTag:
+                    type: string
+                    enum:
+                    - os disk
+                    - data disk
+                  attachedTo:
+                    type: string
+                  bootable:
+                    type: boolean
+                  shared:
+                    type: boolean
+                  sizeMiB:
+                    type: number
+                  createdAt:
+                    type: string
+                  status:
+                    type: object
+                    required:
+                    - current
+                    - isProcessing
+                    properties:
+                      current:
+                        type: string
+                        enum:
+                        - uploading
+                        - importing
+                        - active
+                        - deleting
+                        - error
+                      isProcessing:
+                        type: boolean
+                      processPercent:
+                        type: number
+            page:
+              "$ref": "#/components/schemas/Page"
+        msg:
+          type: string
+          example: volumes retrieved successfully
         status:
           type: string
           example: ok


### PR DESCRIPTION
### What type of PR is this?

Feat and Refactor

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/262

<br/>

### What this PR does?

(📔 All changes can be tried on the 10.32.45.10)

- Refactor the `GET /images` by adding the `page` info in the `response.data`, so that the original `array struct` have to become an `object struct` to place `data.images` and `data.page`

- Add a GET APIs to list volume (support project, watch, pagination, and keyword filter)

- Add a GET APIs to download csv file (support project, pagination, and keyword filter)

- Correct status enum for image and volume

- ⚠️ Add a POST API to convert image to volume

  - ⚠️ when `sourceFromAnotherHypervisor` is `true`, then should use this API rather than `POST /images`

  - ⚠️ reason: during implementing, although, the entry point is the same UI for importing as image or volume. they're totally 2 different resources with different management logic in COS and Openstack.


<br/>

### Test results (optional)

1). make sure no any errors reported from online swagger editor

<img width="1720" height="1030" alt="Screenshot 2025-08-04 at 3 46 12 AM" src="https://github.com/user-attachments/assets/7f1aeb57-3f75-4a1f-ac17-dcb3723073a4" />

<br/>
<br/>
<br/>

2). make sure the corresponding API docs have been updated

https://github.com/user-attachments/assets/f9fa8b02-8b75-49c6-991e-ff01244c4628

