### PR TITLE
Add a `v1ApiDocUrl` field in the data center related apis

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -88,6 +88,7 @@ paths:
                       utcTimeZone: "+00:00"
                       additional:
                         helpUrl: https://www.bigstack.co/contact-us
+                        v1ApiDocUrl: https://example-virtual-ip/api/v1/datacenters/example-datacenter/apidocs/index.html
                         nodeLicenseStatus:
                           valid: 3
                           expired: 0
@@ -146,6 +147,7 @@ paths:
                       utcTimeZone: "+00:00"
                       additional:
                         helpUrl: https://www.bigstack.co/contact-us
+                        v1ApiDocUrl: https://example-virtual-ip/api/v1/datacenters/example-datacenter/apidocs/index.html
                         nodeLicenseStatus:
                           valid: 3
                           expired: 0
@@ -169,6 +171,7 @@ paths:
                       utcTimeZone: "+00:00"
                       additional:
                         helpUrl: https://www.bigstack.co/contact-us
+                        v1ApiDocUrl: https://example-virtual-ip/api/v1/datacenters/example-datacenter/apidocs/index.html
                         nodeLicenseStatus:
                           valid: 3
                           expired: 0
@@ -8923,70 +8926,7 @@ components:
         data:
           type: array
           items:
-            type: object
-            required:
-            - type
-            - name
-            - roles
-            - version
-            - virtualIp
-            - isHaEnabled
-            - isLocal
-            - utcTimeZone
-            - additional
-            properties:
-              type:
-                type: string
-                enum:
-                - cloud
-                - edge
-              name:
-                type: string
-              roles:
-                type: array
-                items:
-                  type: string
-                  enum:
-                  - control-converged
-                  - control
-                  - compute
-                  - storage
-                  - edge-core
-                  - moderator
-              version:
-                type: string
-              virtualIp:
-                type: string
-              isHaEnabled:
-                type: boolean
-              isLocal:
-                type: boolean
-              utcTimeZone:
-                type: string
-              additional:
-                type: object
-                required:
-                - helpUrl
-                - nodeLicenseStatus
-                properties:
-                  helpUrl:
-                    type: string
-                  nodeLicenseStatus:
-                    type: object
-                    required:
-                    - valid
-                    - expired
-                    - unlicense
-                    properties:
-                      valid:
-                        type: integer
-                        example: 1
-                      expired:
-                        type: integer
-                        example: 0
-                      unlicense:
-                        type: integer
-                        example: 0
+            "$ref": "#/components/schemas/DataCenter"
         msg:
           type: string
           example: fetch data center list successfully
@@ -9005,70 +8945,7 @@ components:
           type: integer
           example: 200
         data:
-          type: object
-          required:
-          - type
-          - name
-          - roles
-          - version
-          - virtualIp
-          - isHaEnabled
-          - isLocal
-          - utcTimeZone
-          - additional
-          properties:
-            type:
-              type: string
-              enum:
-              - cloud
-              - edge
-            name:
-              type: string
-            roles:
-              type: array
-              items:
-                type: string
-                enum:
-                - control-converged
-                - control
-                - compute
-                - storage
-                - edge-core
-                - moderator
-            version:
-              type: string
-            virtualIp:
-              type: string
-            isHaEnabled:
-              type: boolean
-            isLocal:
-              type: boolean
-            utcTimeZone:
-              type: string
-            additional:
-              type: object
-              required:
-              - helpUrl
-              - nodeLicenseStatus
-              properties:
-                helpUrl:
-                  type: string
-                nodeLicenseStatus:
-                  type: object
-                  required:
-                  - valid
-                  - expired
-                  - unlicense
-                  properties:
-                    valid:
-                      type: integer
-                      example: 1
-                    expired:
-                      type: integer
-                      example: 0
-                    unlicense:
-                      type: integer
-                      example: 0
+          "$ref": "#/components/schemas/DataCenter"
         msg:
           type: string
           example: fetch data center successfully
@@ -12830,6 +12707,74 @@ components:
         totalItemCount:
           type: integer
           example: 1
+    DataCenter:
+      type: object
+      required:
+      - type
+      - name
+      - roles
+      - version
+      - virtualIp
+      - isHaEnabled
+      - isLocal
+      - utcTimeZone
+      - additional
+      properties:
+        type:
+          type: string
+          enum:
+          - cloud
+          - edge
+        name:
+          type: string
+        roles:
+          type: array
+          items:
+            type: string
+            enum:
+            - control-converged
+            - control
+            - compute
+            - storage
+            - edge-core
+            - moderator
+        version:
+          type: string
+        virtualIp:
+          type: string
+        isHaEnabled:
+          type: boolean
+        isLocal:
+          type: boolean
+        utcTimeZone:
+          type: string
+        additional:
+          type: object
+          required:
+          - helpUrl
+          - v1ApiDocUrl
+          - nodeLicenseStatus
+          properties:
+            helpUrl:
+              type: string
+            v1ApiDocUrl:
+              type: string
+            nodeLicenseStatus:
+              type: object
+              required:
+              - valid
+              - expired
+              - unlicense
+              properties:
+                valid:
+                  type: integer
+                  example: 1
+                expired:
+                  type: integer
+                  example: 0
+                unlicense:
+                  type: integer
+                  example: 0
     Node:
       type: object
       required:


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/293

<br/>

### What this PR does?

- Add a v1ApiDocUrl field in the data center related apis

- Converge data center schema from Get and List APIs to `/components/schemas/DataCenter`

<br/>

### Test results (optional)

1). make sure the api docs and api work well

https://github.com/user-attachments/assets/cac6afd5-dfe1-470e-b55f-36aee95db6bc

