### PR TITLE
Add `reservedImages[].reserved.prefix` and remove `reservedImages[].file` in the image materials api

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -8194,20 +8194,22 @@ paths:
                     code: 200
                     data:
                       reservedImages:
-                      - file: amphora-x64-haproxy-yoga.qcow2
-                        name: amphora-x64-haproxy
+                      - name: amphora-x64-haproxy
                         os: Ubuntu
                         destination: CubeStorage
                         domain: default
                         sourceFromAnotherHypervisor: false
                         visibility: private
-                      - file: manila-service-image_yoga.qcow2
-                        name: manila-service-image
+                        reserved:
+                          prefix: amphora-
+                      - name: manila-service-image
                         os: Ubuntu
                         destination: CubeStorage
                         domain: default
                         sourceFromAnotherHypervisor: false
                         visibility: private
+                        reserved:
+                          prefix: manila-
                       projects:
                       - name: admin
                         domain: default
@@ -12456,7 +12458,6 @@ components:
               items:
                 type: object
                 required:
-                - file
                 - name
                 - os
                 - destination
@@ -12464,9 +12465,8 @@ components:
                 - project
                 - sourceFromAnotherHypervisor
                 - visibility
+                - reserved
                 properties:
-                  file:
-                    type: string
                   name:
                     type: string
                   os:
@@ -12481,6 +12481,13 @@ components:
                     type: boolean
                   visibility:
                     type: string
+                  reserved:
+                    type: object
+                    required:
+                    - prefix
+                    properties:
+                      prefix:
+                        type: string
             projects:
               type: array
               items:


### PR DESCRIPTION
### What type of PR is this?

Fix

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/239

<br/>

### What this PR does?

Adjust 2 things below in the image materials api

- Add `reservedImages[].reserved.prefix`

- Remove `reservedImages[].file`

<br/>

### Test results (optional)

1). make sure the api doc has been updated.

<img width="888" height="1036" alt="Screenshot 2025-08-11 at 3 52 44 PM" src="https://github.com/user-attachments/assets/c1ca2df1-8dd4-4425-850d-4cb881235271" />

<br/>
<br/>
<br/>

2). make sure the api works well.

<img width="679" height="1031" alt="Screenshot 2025-08-11 at 4 01 26 PM" src="https://github.com/user-attachments/assets/39579333-40e0-454e-9ef2-645bb7e7740f" />
