### PR TITLE
fix: firmwares api md5 verification typo

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -8892,7 +8892,7 @@ paths:
                     example: internal server error
   "/api/v1/datacenters/{dataCenter}/firmwares/md5sum/verify":
     post:
-      operationId: vierfyFirmwareMd5Sum
+      operationId: verifyFirmwareMd5Sum
       tags:
       - Firmwares
       summary: Verify the firmware MD5 sum
@@ -8916,6 +8916,9 @@ paths:
                     example: 200
                   data:
                     type: object
+                    required:
+                    - firmwareMd5
+                    - expectedMd5
                     properties:
                       firmwareMd5:
                         type: string


### PR DESCRIPTION
### What type of PR is this?

Fix

### Which issue(s) this PR fixes?

None

### What this PR does?

- Fix firmwares md5 verify API operation id typo.
- Mark the md5 checksum properties as required in the 200 response of the firmwares md5 verify API.

### Test results (optional)

<img width="403" height="293" alt="{B29FF7AF-E063-438F-B993-C706C2285C18}" src="https://github.com/user-attachments/assets/e8e7d12b-c110-48b9-af68-cf0605892f46" />

