### PR TITLE
Add some new fields/values for fixpack and firmware's progress data

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -9908,6 +9908,7 @@ paths:
                     code: 200
                     data:
                       version: FIX_001
+                      operation: install
                       progresses:
                       - host: example-node-0
                         phase: ''
@@ -14351,6 +14352,7 @@ components:
                         - available
                         - processing
                         - updated
+                        - failed
                       isUpdatable:
                         type: boolean
                       isProcessing:
@@ -14511,7 +14513,8 @@ components:
                         - installing
                         - installed
                         - rolling back
-                        - failed
+                        - install failed
+                        - rollback failed
                       isInstallable:
                         type: boolean
                       isRollbackable:
@@ -14577,10 +14580,16 @@ components:
           type: object
           required:
           - version
+          - operation
           - progresses
           properties:
             version:
               type: string
+            operation:
+              type: string
+              enum:
+              - install
+              - rollback
             progresses:
               type: array
               items:
@@ -14609,7 +14618,8 @@ components:
                         - installing
                         - installed
                         - rolling back
-                        - failed
+                        - install failed
+                        - rollback failed
                       isProcessing:
                         type: boolean
                       processPercent:


### PR DESCRIPTION
### What type of PR is this?

Refactor

💡 The APIs and OpenAPI spec have been deployed and tested on the 45.10, can interact with it from the staging env.

<br/>

### Which issue(s) this PR fixes?

- https://github.com/bigstack-oss/cubecos/issues/284

- https://github.com/bigstack-oss/cubecos/issues/279

- https://github.com/bigstack-oss/cubecos/issues/271

<br/>

### What this PR does?

- add `install failed` and `rollback failed` in the status enum for listFixpack and getFixpackUpdateProgress

- add a new field `operation` in the getFixpackUpdateProgress (the enum includes `install` and `rollback`)

- add `failed` in the status enum for listFirmwares and getFirmwareUpgradeProgress

<br/>

### Test results (optional)

1). make sure no any errors from online swagger doc

<img width="1913" height="1029" alt="Screenshot 2025-08-31 at 2 33 54 PM" src="https://github.com/user-attachments/assets/416442d2-1338-41b5-b87b-271f71aa23eb" />
