### PR TITLE
Fix fixpack md5 verification's incorrect 400 and 409 response schema

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -9823,7 +9823,7 @@ paths:
                   data:
                     type: object
                     properties:
-                      firmwareMd5:
+                      fixpackMd5:
                         type: string
                         example: vvvwewegrehnfxcvxhn52b6wefh4123g
                       expectedMd5:
@@ -9843,22 +9843,12 @@ paths:
                 type: object
                 required:
                 - code
-                - data
                 - msg
                 - status
                 properties:
                   code:
                     type: integer
                     example: 409
-                  data:
-                    type: object
-                    properties:
-                      firmwareMd5:
-                        type: string
-                        example: vvvwewegrehnfxcvxhn52b6wefh4123g
-                      expectedMd5:
-                        type: string
-                        example: c18ce9ddf80b065004152b6f2e609ff8
                   msg:
                     type: string
                     example: "'FIX_001' md5 verification is already in progress"


### PR DESCRIPTION
### What type of PR is this?

Feat

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/315

<br/>

### What this PR does?

- Fix the typo in the fixpack's md5 verification 400 response schema

- Remove the data object in the fixpack's md5 verification 409 response schema
