### PR TITLE
Add node name for /fixpacks/continueAnyway/{nodeName} 

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -14439,6 +14439,7 @@ components:
                         - rebooting
                         - installed
                         - failed
+                        - resolved
                       isProcessing:
                         type: boolean
                       processPercent:
@@ -14613,6 +14614,7 @@ components:
                         - waitingReboot
                         - rebooting
                         - installed
+                        - resolved
                         - rolling back
                         - install failed
                         - rollback failed

--- a/docs.yaml
+++ b/docs.yaml
@@ -9642,7 +9642,7 @@ paths:
                   status:
                     type: string
                     example: internal server error
-  "/api/v1/datacenters/{dataCenter}/fixpacks/continueAnyway":
+  "/api/v1/datacenters/{dataCenter}/fixpacks/continueAnyway/{nodeName}":
     post:
       operationId: continueInterruptedFixpackUpdate
       tags:
@@ -9650,6 +9650,7 @@ paths:
       summary: Continue an interrupted fixpack update
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/nodeName"
       responses:
         '202':
           description: Fixpack update continued successfully
@@ -9683,7 +9684,7 @@ paths:
                     example: 400
                   msg:
                     type: string
-                    example: no interrupted fixpack update found to continue
+                    example: node not found for continue fixpack update
                   status:
                     type: string
                     example: bad request
@@ -9939,71 +9940,6 @@ paths:
                   status:
                     type: string
                     example: "'internal server error"
-    delete:
-      operationId: deleteFixpack
-      tags:
-      - Fixpacks
-      summary: Delete a fixpack
-      parameters:
-      - "$ref": "#/components/parameters/dataCenter"
-      - "$ref": "#/components/parameters/version"
-      responses:
-        '200':
-          description: Fixpack deleted successfully
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                - code
-                - msg
-                - status
-                properties:
-                  code:
-                    type: integer
-                    example: 200
-                  msg:
-                    type: string
-                    example: Fixpack deleted successfully
-                  status:
-                    type: string
-                    example: ok
-        '404':
-          description: Not Found
-          content:
-            application/json:
-              schema:
-                type: object
-                required:
-                - code
-                - msg
-                - status
-                properties:
-                  code:
-                    type: integer
-                    example: 404
-                  msg:
-                    type: string
-                    example: "'FIX_001' not found"
-                  status:
-                    type: string
-                    example: "'FIX_001' not found"
-        '500':
-          description: Internal Server Error
-          content:
-            application/json:
-              schema:
-                type: object
-                properties:
-                  code:
-                    type: integer
-                    example: 500
-                  msg:
-                    type: string
-                    example: 'failed to delete fixpack: internal server error'
-                  status:
-                    type: string
-                    example: internal server error
   "/api/v1/datacenters/{dataCenter}/fixpacks/{version}/rollback":
     post:
       operationId: rollbackFixpack
@@ -10180,6 +10116,72 @@ paths:
                   msg:
                     type: string
                     example: 'failed to list updatable nodes: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/fixpacks/{version}":
+    delete:
+      operationId: deleteFixpack
+      tags:
+      - Fixpacks
+      summary: Delete a fixpack
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/version"
+      responses:
+        '200':
+          description: Fixpack deleted successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - code
+                - msg
+                - status
+                properties:
+                  code:
+                    type: integer
+                    example: 200
+                  msg:
+                    type: string
+                    example: Fixpack deleted successfully
+                  status:
+                    type: string
+                    example: ok
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - code
+                - msg
+                - status
+                properties:
+                  code:
+                    type: integer
+                    example: 404
+                  msg:
+                    type: string
+                    example: "'FIX_001' not found"
+                  status:
+                    type: string
+                    example: not found
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to delete fixpack: internal server error'
                   status:
                     type: string
                     example: internal server error


### PR DESCRIPTION
### What type of PR is this?

Refactor and fix

💡 The APIs and OpenAPI spec have been deployed and tested on the 45.10, can interact with it from the staging env.

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/320

<br/>

### What this PR does?

- adjust the `/fixpacks/continueAnyway` to `/fixpacks/continueAnyway/{nodeName}`

- also fix the incorrect DELETION interface for fixpack removal.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

<img width="1426" height="889" alt="Screenshot 2025-09-04 at 12 54 07 PM" src="https://github.com/user-attachments/assets/dfd7dcfb-147a-47cc-b038-be494d623ec5" />

<br/>
<br/>

<img width="1437" height="919" alt="Screenshot 2025-09-04 at 12 53 51 PM" src="https://github.com/user-attachments/assets/9fe8eda0-baf1-459f-a4a9-5907bda2112d" />


