### PR TITLE
fix: soft reboot data center response schema required fields

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -221,6 +221,10 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                - code
+                - msg
+                - status
                 properties:
                   code:
                     type: integer
@@ -238,6 +242,10 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                - code
+                - msg
+                - status
                 properties:
                   code:
                     type: integer
@@ -255,6 +263,10 @@ paths:
             application/json:
               schema:
                 type: object
+                required:
+                - code
+                - msg
+                - status
                 properties:
                   code:
                     type: integer
@@ -9826,7 +9838,6 @@ paths:
       summary: Get the progress of a fixpack operation
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
-      - "$ref": "#/components/parameters/version"
       responses:
         '200':
           description: Fixpack update progress


### PR DESCRIPTION
### What type of PR is this?

Fix

### Which issue(s) this PR fixes?

None

### What this PR does?

- Mark `code`, `msg`, and `status` as required in all response schemas of the rolloutDataCenterBySoftReboot API.
- Remove the unnecessary `version` parameter from the getFixpackProgress API.

### Test results (optional)

<img width="489" height="564" alt="{65FFA376-70C9-4AEA-BB32-C61FDBF6B5C1}" src="https://github.com/user-attachments/assets/1117dfb9-6883-4df0-9e10-0ea6a73bf768" />
