### PR TITLE
Add PATCH /images/{imageId} and adjust GET /images by adding diskType and metadata

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -9574,7 +9574,24 @@ paths:
                         domainName: default
                         projectName: admin
                         visibilityType: public
+                        diskType: raw
                         createdAt: '2025-07-27T13:08:53+08:00'
+                        metadata:
+                          cubeDefinedDestination: CubeStorage
+                          cubeDefinedOs: Ubuntu
+                          direct_url: rbd://c6e64c49-09cf-463b-9d1c-b6645b4b3b85/glance-images/59be046d-0199-407d-88d4-a833dbbd2420/snap
+                          hw_disk_bus: scsi
+                          hw_input_bus: virtio
+                          hw_machine_type: q35
+                          hw_qemu_guest_agent: 'yes'
+                          hw_scsi_model: virtio-scsi
+                          hw_video_model: vga
+                          os_admin_user: other
+                          os_distro: Ubuntu
+                          os_hash_algo: sha512
+                          os_hash_value: 7f6b1fcdca809920b3bbba6fdec139d9e47484548c4188fe4efa0bf2434a9f15f836e74100848e0e6f678400ca1e2f174f93826a0effcf16044e17d0bf7d7d66
+                          os_require_quiesce: 'yes'
+                          os_vers: example image 0
                         status:
                           current: active
                           isProcessing: false
@@ -9586,6 +9603,22 @@ paths:
                         projectName: admin
                         visibilityType: private
                         createdAt: '2025-07-29T13:08:53+08:00'
+                        metadata:
+                          cubeDefinedDestination: CubeStorage
+                          cubeDefinedOs: Ubuntu
+                          direct_url: rbd://c6e64c49-09cf-463b-9d1c-b6645b4b3b85/glance-images/59be046d-0199-407d-88d4-a833dbbd2420/snap
+                          hw_disk_bus: scsi
+                          hw_input_bus: virtio
+                          hw_machine_type: q35
+                          hw_qemu_guest_agent: 'yes'
+                          hw_scsi_model: virtio-scsi
+                          hw_video_model: vga
+                          os_admin_user: other
+                          os_distro: Ubuntu
+                          os_hash_algo: sha512
+                          os_hash_value: 9f6b1fcdca809920b3bbba6fdec139d9e47484548c4188fe4efa0bf2434a9f15f836e74100848e0e6f678400ca1e2f174f93826a0effcf16044e17d0bf7d7d66
+                          os_require_quiesce: 'yes'
+                          os_vers: example image 1
                         status:
                           current: importing
                           isProcessing: true
@@ -9672,6 +9705,137 @@ paths:
                   msg:
                     type: string
                     example: 'failed to import image: internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/images/{imageId}":
+    patch:
+      operationId: updateImage
+      tags:
+      - Images
+      summary: Update an image
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - in: path
+        name: imageId
+        required: true
+        schema:
+          type: string
+        description: The id of the image
+        example: 763655de-1cfc-45d4-b67c-5579ea43a6e1
+      requestBody:
+        description: At least one of the fields must be provided.
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                name:
+                  type: string
+                  description: The new name of the image
+                  example: renamed-example-image
+                os:
+                  type: string
+                  description: The new operating system type of the image
+                  example: Ubuntu
+                visibility:
+                  type: string
+                  description: The new visibility type of the image, can be either
+                    'public' or 'private'
+                  enum:
+                  - public
+                  - private
+                  example: private
+            examples:
+              example:
+                summary: Update image request
+                value:
+                  name: renamed-example-image
+                  os: Ubuntu
+                  visibility: private
+      responses:
+        '200':
+          description: Image updated successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                - code
+                - msg
+                - status
+                properties:
+                  code:
+                    type: integer
+                    example: 200
+                  msg:
+                    type: string
+                    example: image updated successfully
+                  status:
+                    type: string
+                    example: ok
+        '400':
+          description: Bad Request
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 400
+                  msg:
+                    type: string
+                    example: at least one of the fields must be provided
+                  status:
+                    type: string
+                    example: bad request
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 404
+                  msg:
+                    type: string
+                    example: image not found
+                  status:
+                    type: string
+                    example: not found
+        '409':
+          description: Conflict
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 409
+                  msg:
+                    type: string
+                    example: image is under processing, cannot be updated
+                  status:
+                    type: string
+                    example: conflict
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to update image: internal server error'
                   status:
                     type: string
                     example: internal server error
@@ -15733,6 +15897,8 @@ components:
                 - project
                 - visibility
                 - sizeMiB
+                - diskType
+                - metadata
                 - createdAt
                 - status
                 properties:
@@ -15756,10 +15922,59 @@ components:
                     - shared
                     - community
                     - unknown
+                  diskType:
+                    type: string
+                    enum:
+                    - raw
+                    - qcow2
+                    - vhd
+                    - vmdk
+                    - iso
+                    - unknown
                   createdAt:
                     type: string
                   sizeMiB:
                     type: number
+                  metadata:
+                    type: object
+                    description: Free-form metadata; may be empty {}
+                    properties:
+                      cubeDefinedDestination:
+                        type: string
+                      cubeDefinedOs:
+                        type: string
+                      direct_url:
+                        type: string
+                      hw_disk_bus:
+                        type: string
+                      hw_input_bus:
+                        type: string
+                      hw_machine_type:
+                        type: string
+                      hw_qemu_guest_agent:
+                        type: string
+                        enum:
+                        - 'yes'
+                        - 'no'
+                      hw_scsi_model:
+                        type: string
+                      hw_video_model:
+                        type: string
+                      os_admin_user:
+                        type: string
+                      os_distro:
+                        type: string
+                      os_hash_algo:
+                        type: string
+                      os_hash_value:
+                        type: string
+                      os_require_quiesce:
+                        type: string
+                        enum:
+                        - 'yes'
+                        - 'no'
+                      os_vers:
+                        type: string
                   status:
                     type: object
                     required:

--- a/docs.yaml
+++ b/docs.yaml
@@ -9573,7 +9573,7 @@ paths:
                         destination: CubeStorage
                         domainName: default
                         projectName: admin
-                        visibilityType: public
+                        visibility: public
                         diskType: raw
                         createdAt: '2025-07-27T13:08:53+08:00'
                         metadata:
@@ -9601,7 +9601,7 @@ paths:
                         destination: CubeStorage
                         domainName: default
                         projectName: admin
-                        visibilityType: private
+                        visibility: private
                         createdAt: '2025-07-29T13:08:53+08:00'
                         metadata:
                           cubeDefinedDestination: CubeStorage


### PR DESCRIPTION
### What type of PR is this?

Feat and refactor

<br/>

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cubecos/issues/377

<br/>

### What this PR does?

- Add a new PATCH /images/{imageId} to edit an image

- Add `diskType` and `metadata` in the GET /images

- Add/adjust the corresponding api docs

<br/>

### Test results (optional)

1). make sure no any errors from online swagger editor

<img width="1911" height="1034" alt="Screenshot 2025-09-16 at 6 42 57 PM" src="https://github.com/user-attachments/assets/63cc1dd3-d6c2-4e15-96a2-3c9b0bb9bc5a" />

<br/>
<br/>
<br/>

2). make sure the api docs have been updated

for PATCH /images/{imageId}

https://github.com/user-attachments/assets/f4506457-99a8-4c17-97bd-c9e8fb6dea4a

for GET /images

https://github.com/user-attachments/assets/ce25ccf7-9b53-452b-a037-b303c31f8d92

