### PR TITLE
feat: add isRollingApplied property to GetFirmwareUpgradeProgressResponse

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -10258,6 +10258,7 @@ paths:
                     code: 200
                     data:
                       version: CUBE Appliance 3.1.0
+                      isRollingApplied: true
                       progresses:
                       - host: example-node-0
                         phase: paritioning
@@ -15982,10 +15983,13 @@ components:
           type: object
           required:
           - version
+          - isRollingApplied
           - progresses
           properties:
             version:
               type: string
+            isRollingApplied:
+              type: boolean
             progresses:
               type: array
               items:


### PR DESCRIPTION
### What type of PR is this?

Feat

### Which issue(s) this PR fixes?

None

### What this PR does?

Add `isRollingApplied: boolean` to `GetFirmwareUpgradeProgressResponse`.

### Test results (optional)

<img width="452" height="346" alt="{5EE3B642-8958-44D8-98A4-C55D797CE0CC}" src="https://github.com/user-attachments/assets/be3093cb-05e5-456c-aeee-ead760af6e77" />

<img width="521" height="441" alt="{497F47E4-5B6C-4E8D-A0AA-45CBFCCCF211}" src="https://github.com/user-attachments/assets/5191f287-f41b-41d7-9b37-7b14318642b3" />
