### PR TITLE
fix(storage integration): create/update storage model req body should…

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -13299,7 +13299,7 @@ components:
       properties:
         storageModels:
           type: string
-          format: text
+          format: binary
           description: The array YAML content of multiple storage models
     ApplyIntegreationStorageModelsRequest:
       type: object
@@ -13308,7 +13308,7 @@ components:
       properties:
         storageModel:
           type: string
-          format: file
+          format: binary
           description: The YAML content of a storage model
     GetLicensesResponse:
       type: object


### PR DESCRIPTION
### What type of PR is this?

Fix

### What this PR does?

The storageModel field in `POST/PUT/PATCH storage/models` should be `binary` format instead of `file` or `text`.

### Screenshots:

<img width="917" height="787" alt="截圖 2025-10-28 下午4 21 05" src="https://github.com/user-attachments/assets/de769f15-90f4-4848-bfd9-e73ea43ba0c6" />

<img width="929" height="579" alt="截圖 2025-10-28 下午4 21 25" src="https://github.com/user-attachments/assets/f96a92f0-7bbd-4c19-b1b3-2263c8f013bc" />

<img width="938" height="529" alt="截圖 2025-10-28 下午4 21 43" src="https://github.com/user-attachments/assets/ac8acf51-1903-45b4-81ab-d15a152ebe7a" />

### Test results (optional)

manually validate Passed.

<img width="1129" height="203" alt="image" src="https://github.com/user-attachments/assets/a7d2addc-2b5c-44ea-8e03-4f1b0cddadf1" />

