### PR TITLE
Remove the type and vendor field in the toast notification of storage model

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -17964,8 +17964,6 @@ components:
         additionalInfo:
           type: object
           required:
-          - type
-          - vendor
           - driver
           properties:
             type:
@@ -17993,8 +17991,6 @@ components:
         additionalInfo:
           type: object
           required:
-          - type
-          - vendor
           - driver
           properties:
             type:
@@ -18024,8 +18020,6 @@ components:
         additionalInfo:
           type: object
           required:
-          - type
-          - vendor
           - driver
           properties:
             type:
@@ -18082,8 +18076,6 @@ components:
         additionalInfo:
           type: object
           required:
-          - type
-          - vendor
           - driver
           properties:
             type:
@@ -18111,8 +18103,6 @@ components:
         additionalInfo:
           type: object
           required:
-          - type
-          - vendor
           - driver
           properties:
             type:

--- a/docs.yaml
+++ b/docs.yaml
@@ -12848,7 +12848,7 @@ components:
                     type: string
                     enum:
                     - ok
-                    - validating
+                    - verifying
                     - creating
                     - updating
                     - deleting
@@ -17966,10 +17966,6 @@ components:
           required:
           - driver
           properties:
-            type:
-              type: string
-            vendor:
-              type: string
             driver:
               type: string
     MDL00001E:
@@ -17993,10 +17989,6 @@ components:
           required:
           - driver
           properties:
-            type:
-              type: string
-            vendor:
-              type: string
             driver:
               type: string
             description:
@@ -18047,14 +18039,8 @@ components:
         additionalInfo:
           type: object
           required:
-          - type
-          - vendor
           - driver
           properties:
-            type:
-              type: string
-            vendor:
-              type: string
             driver:
               type: string
     MDL00003I:
@@ -18078,10 +18064,6 @@ components:
           required:
           - driver
           properties:
-            type:
-              type: string
-            vendor:
-              type: string
             driver:
               type: string
     MDL00003E:
@@ -18105,10 +18087,6 @@ components:
           required:
           - driver
           properties:
-            type:
-              type: string
-            vendor:
-              type: string
             driver:
               type: string
     STG00001I:

--- a/docs.yaml
+++ b/docs.yaml
@@ -16624,7 +16624,7 @@ components:
                         enum:
                         - available
                         - installing
-                        - waitingReboot
+                        - waiting reboot
                         - rebooting
                         - installed
                         - rolling back
@@ -17397,6 +17397,10 @@ components:
       - "$ref": "#/components/schemas/STG00002E"
       - "$ref": "#/components/schemas/STG00003I"
       - "$ref": "#/components/schemas/STG00003E"
+      - "$ref": "#/components/schemas/STG00004I"
+      - "$ref": "#/components/schemas/STG00004E"
+      - "$ref": "#/components/schemas/STG00005I"
+      - "$ref": "#/components/schemas/STG00005E"
       discriminator:
         propertyName: id
         mapping:
@@ -18014,10 +18018,6 @@ components:
           required:
           - driver
           properties:
-            type:
-              type: string
-            vendor:
-              type: string
             driver:
               type: string
     MDL00002E:
@@ -18207,6 +18207,110 @@ components:
             name:
               type: string
     STG00003E:
+      type: object
+      required:
+      - id
+      - nodeName
+      - time
+      - additionalInfo
+      properties:
+        id:
+          type: string
+          pattern: "^STG"
+        nodeName:
+          type: string
+        time:
+          type: string
+          format: date-time
+        additionalInfo:
+          type: object
+          required:
+          - name
+          properties:
+            name:
+              type: string
+    STG00004I:
+      type: object
+      required:
+      - id
+      - nodeName
+      - time
+      - additionalInfo
+      properties:
+        id:
+          type: string
+          pattern: "^STG"
+        nodeName:
+          type: string
+        time:
+          type: string
+          format: date-time
+        additionalInfo:
+          type: object
+          required:
+          - name
+          - isCinderServiceUp
+          - isTestVolumeSuccessful
+          properties:
+            name:
+              type: string
+            isCinderServiceUp:
+              type: boolean
+            isTestVolumeSuccessful:
+              type: boolean
+    STG00004E:
+      type: object
+      required:
+      - id
+      - nodeName
+      - time
+      - additionalInfo
+      properties:
+        id:
+          type: string
+          pattern: "^STG"
+        nodeName:
+          type: string
+        time:
+          type: string
+          format: date-time
+        additionalInfo:
+          type: object
+          required:
+          - name
+          - isCinderServiceUp
+          - isTestVolumeSuccessful
+          properties:
+            name:
+              type: string
+            isCinderServiceUp:
+              type: boolean
+            isTestVolumeSuccessful:
+              type: boolean
+    STG00005I:
+      type: object
+      required:
+      - id
+      - nodeName
+      - time
+      - additionalInfo
+      properties:
+        id:
+          type: string
+          pattern: "^STG"
+        nodeName:
+          type: string
+        time:
+          type: string
+          format: date-time
+        additionalInfo:
+          type: object
+          required:
+          - name
+          properties:
+            name:
+              type: string
+    STG00005E:
       type: object
       required:
       - id


### PR DESCRIPTION
### What type of PR is this?

Refactor

<br/>

### Which issue(s) this PR fixes?

None

<br/>

### What this PR does?

- Remove the type and vendor field in the toast notification of storage model

- Adding the STG00004I/E(verification) and STG00005I/E(setting to default) (both have been updated to the spreadsheet as well https://docs.google.com/spreadsheets/d/196Xy8s6K4PcvpJjQIxX4VAFQzI_ETY2DTbOAODT7AaY/edit?gid=1674446536#gid=1674446536)

- Replace the validating with verifying since designer changed the wording.