### PR TITLE
feat(integration storage): add setting to default enum to status

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -12852,6 +12852,7 @@ components:
                     - creating
                     - updating
                     - deleting
+                    - setting to default
                   isProcessing:
                     type: boolean
         msg:


### PR DESCRIPTION
### What type of PR is this?

feat

### Which issue(s) this PR fixes?

N/A

### What this PR does?

According to the API response, the  `status.current` includes`setting to default`, but this value isn't defined in the OpenAPI spec, so I added it to the `status.current` enum.

<img width="2031" height="1161" alt="截圖 2025-11-03 晚上7 55 30" src="https://github.com/user-attachments/assets/dd0420f0-70f6-4808-92e4-11cdf15fb806" />

### Test results (optional)

Manual test passed.

<img width="1137" height="220" alt="image" src="https://github.com/user-attachments/assets/6ad9f20d-f980-45c4-bcc2-aab8c7ef4ccb" />

