### PR TITLE
Make project query param to be optional in the GET /volumes

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -9927,7 +9927,7 @@ paths:
       summary: List volumes
       parameters:
       - "$ref": "#/components/parameters/dataCenter"
-      - "$ref": "#/components/parameters/project"
+      - "$ref": "#/components/parameters/projectNotRequired"
       - "$ref": "#/components/parameters/watch"
       - "$ref": "#/components/parameters/pageSize"
       - "$ref": "#/components/parameters/pageNum"


### PR DESCRIPTION
### What type of PR is this?

Refactor

<br/>

### Which issue(s) this PR fixes?

None

<br/>

### What this PR does?

Make project query param to be optional in the GET /volumes

<br/>

### Test results (optional)

<img width="1130" height="832" alt="Screenshot 2025-11-07 at 11 53 23 AM" src="https://github.com/user-attachments/assets/0f94e7d1-d58d-4d76-8e78-a57bdb7c5990" />

