### PR TITLE
feat(license): feature and support plan add N/A enum

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -13449,21 +13449,13 @@ components:
                       name:
                         type: string
                       feature:
-                        type: string
-                        enum:
-                        - basic
-                        - advanced
-                        - premium
+                        "$ref": "#/components/schemas/LicenseFeature"
                   issue:
                     "$ref": "#/components/schemas/LicenseIssue"
                   quantity:
                     type: string
                   supportPlan:
-                    type: string
-                    enum:
-                    - ESA
-                    - EEA
-                    - FMA
+                    "$ref": "#/components/schemas/LicenseSupportPlan"
                   expiry:
                     type: object
                     required:
@@ -13532,13 +13524,13 @@ components:
                     name:
                       type: string
                     feature:
-                      type: string
+                      "$ref": "#/components/schemas/LicenseFeature"
                 issue:
                   "$ref": "#/components/schemas/LicenseIssue"
                 quantity:
                   type: string
                 supportPlan:
-                  type: string
+                  "$ref": "#/components/schemas/LicenseSupportPlan"
                 expiry:
                   type: object
                   required:
@@ -17049,13 +17041,13 @@ components:
                 name:
                   type: string
                 feature:
-                  type: string
+                  "$ref": "#/components/schemas/LicenseFeature"
             issue:
               "$ref": "#/components/schemas/LicenseIssue"
             quantity:
               type: string
             supportPlan:
-              type: string
+              "$ref": "#/components/schemas/LicenseSupportPlan"
             expiry:
               type: object
               required:
@@ -17457,6 +17449,20 @@ components:
           - expired
         isExpiring:
           type: boolean
+    LicenseFeature:
+      type: string
+      enum:
+      - N/A  
+      - basic
+      - advanced
+      - premium
+    LicenseSupportPlan:
+      type: string
+      enum:
+      - N/A
+      - ESA
+      - EEA
+      - FMA
     SettingStatus:
       type: object
       required:


### PR DESCRIPTION
### What type of PR is this?

### Which issue(s) this PR fixes?

N/A

### What this PR does?

1. feat(license): feature and support plan add N/A enum
2. feat(license): extract `LicenseFeature` and `LicenseSupportPlan` enum.

<img width="787" height="226" alt="截圖 2025-11-18 下午2 28 45" src="https://github.com/user-attachments/assets/15b53da5-9925-4d1d-9045-85e8923325ac" />

<img width="692" height="607" alt="截圖 2025-11-18 下午2 29 26" src="https://github.com/user-attachments/assets/ac9d94a5-5d19-4be0-846d-f99d53cc05ce" />

<img width="648" height="492" alt="截圖 2025-11-18 下午2 30 05" src="https://github.com/user-attachments/assets/015e197c-7376-4bf2-962b-fbbf43890b3d" />

<img width="639" height="731" alt="截圖 2025-11-18 下午2 31 12" src="https://github.com/user-attachments/assets/320b7acc-d6f0-465d-9dc6-845e891202b5" />


### Test results (optional)

Manual validation passed.

<img width="1067" height="200" alt="image" src="https://github.com/user-attachments/assets/539ede2f-3904-4a56-bd99-f261b9fefd9f" />
