### PR TITLE
fix: missing stg notifications id mapping

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -17562,6 +17562,10 @@ components:
           STG00002E: "#/components/schemas/STG00002E"
           STG00003I: "#/components/schemas/STG00003I"
           STG00003E: "#/components/schemas/STG00003E"
+          STG00004I: "#/components/schemas/STG00004I"
+          STG00004E: "#/components/schemas/STG00004E"
+          STG00005I: "#/components/schemas/STG00005I"
+          STG00005E: "#/components/schemas/STG00005E"
     StorageModel:
       type: object
       required:


### PR DESCRIPTION
### What type of PR is this?

Fix

### Which issue(s) this PR fixes?

None

### What this PR does?

Add the missing notifications ID mapping. Including:

- `STG00004E`
- `STG00004I`
- `STG00005E`
- `STG00005I`

### Test results (optional)

<img width="1241" height="249" alt="{9CD1C22F-362D-4F04-ADD6-2D1C48CEDBA8}" src="https://github.com/user-attachments/assets/5da60b34-a9c8-4a3e-9861-1bd256730c0b" />
