### PR TITLE
fix: add missing node device enum

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -14580,6 +14580,7 @@ components:
                     - ok
                     - warning
                     - fail
+                    - processing
                   isPromotable:
                     type: boolean
                   isDemotable:


### PR DESCRIPTION
### What type of PR is this?

Fix

### Which issue(s) this PR fixes?

https://github.com/bigstack-oss/cube-cos-ui/issues/740, please checkout the last screenshot.
The COS UI needs the enum to translate the enum correctly.

<img width="2163" height="377" alt="image" src="https://github.com/user-attachments/assets/24df6dc6-f38f-4cd4-8ee1-55ae6a317abb" />

### What this PR does?

fix: add missing node device enum

Changes:

<img width="755" height="742" alt="截圖 2025-12-18 晚上7 27 52" src="https://github.com/user-attachments/assets/d6fc166f-d033-4889-8697-08df6f1c7721" />

<img width="573" height="553" alt="截圖 2025-12-18 晚上7 27 34" src="https://github.com/user-attachments/assets/c668b1c7-38fe-431c-91d9-3a6ac0bd39b9" />

### Test results (optional)

Manually validated.

<img width="976" height="230" alt="image" src="https://github.com/user-attachments/assets/c8ad63bc-6e47-4cfa-8963-74252c4deff6" />

