### PR TITLE
fix: add missing node device status enum unknown

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -14581,6 +14581,7 @@ components:
                     - warning
                     - fail
                     - processing
+                    - unknown
                   isPromotable:
                     type: boolean
                   isDemotable:


### PR DESCRIPTION
### What type of PR is this?

Fix

### Which issue(s) this PR fixes?

### What this PR does?

fix: add missing node device status enum `unknown`

<img width="3324" height="1762" alt="image" src="https://github.com/user-attachments/assets/8dbf164b-6011-4617-a997-ef7c411c932a" />

<img width="778" height="753" alt="截圖 2025-12-19 晚上7 01 43" src="https://github.com/user-attachments/assets/59395a6a-675c-4764-8b8b-33492e992433" />

<img width="749" height="627" alt="截圖 2025-12-19 晚上7 02 02" src="https://github.com/user-attachments/assets/424cc4e0-48ba-4c1c-9229-f8ec041e40b2" />


### Test results (optional)

Manually validated.

<img width="1146" height="235" alt="image" src="https://github.com/user-attachments/assets/173c4348-5626-4304-af57-c6e3fc938e81" />
