### PR TITLE
docs(grafana): add device GPU utilization/vram deep-link endpoints (#824)

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -9465,6 +9465,92 @@ paths:
                   status:
                     type: string
                     example: internal server error
+  "/api/v1/datacenters/{dataCenter}/grafana/devices/{hostname}/gpuUtilization":
+    get:
+      operationId: getGrafanaDeviceGpuUtilization
+      tags:
+      - Grafana
+      summary: Get Grafana device GPU utilization history dashboard link
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/hostname"
+      responses:
+        '200':
+          description: Get Grafana device GPU utilization history dashboard link
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GetGrafanaDashboardLinkResponse"
+              examples:
+                example:
+                  summary: Device GPU utilization history dashboard link
+                  value:
+                    code: 200
+                    data:
+                      link: http://example-data-center/grafana/d/i-device/device?orgId=1&var-GPU_HOST=example-node-0&from=now-3h&to=now&viewPanel=50
+                      enabled: true
+                    msg: fetch device gpu utilization link successfully
+                    status: ok
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to get Grafana device GPU utilization dashboard:
+                      internal server error'
+                  status:
+                    type: string
+                    example: internal server error
+  "/api/v1/datacenters/{dataCenter}/grafana/devices/{hostname}/gpuVram":
+    get:
+      operationId: getGrafanaDeviceGpuVram
+      tags:
+      - Grafana
+      summary: Get Grafana device GPU VRAM usage history dashboard link
+      parameters:
+      - "$ref": "#/components/parameters/dataCenter"
+      - "$ref": "#/components/parameters/hostname"
+      responses:
+        '200':
+          description: Get Grafana device GPU VRAM usage history dashboard link
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/GetGrafanaDashboardLinkResponse"
+              examples:
+                example:
+                  summary: Device GPU VRAM usage history dashboard link
+                  value:
+                    code: 200
+                    data:
+                      link: http://example-data-center/grafana/d/i-device/device?orgId=1&var-GPU_HOST=example-node-0&from=now-3h&to=now&viewPanel=51
+                      enabled: true
+                    msg: fetch device gpu vram link successfully
+                    status: ok
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  code:
+                    type: integer
+                    example: 500
+                  msg:
+                    type: string
+                    example: 'failed to get Grafana device GPU vram dashboard: internal
+                      server error'
+                  status:
+                    type: string
+                    example: internal server error
   "/api/v1/datacenters/{dataCenter}/grafana/instances/{instanceId}":
     get:
       operationId: getGrafanaInstances


### PR DESCRIPTION
### What type of PR is this?

Docs — OpenAPI spec (document two new endpoints).

<br/>

### Which issue(s) this PR fixes?

Backend track of bigstack-oss/cubecos#824 and bigstack-oss/cubecos#825. Documents the endpoints implemented in cube-cos-api (companion PR bigstack-oss/cube-cos-api#596).

<br/>

### What this PR does?

Adds the OpenAPI definitions for two device-scoped Grafana deep-link endpoints (Device dashboard `i-device`):

```
GET /api/v1/datacenters/{dataCenter}/grafana/devices/{hostname}/gpuUtilization   (panel 50)
GET /api/v1/datacenters/{dataCenter}/grafana/devices/{hostname}/gpuVram          (panel 51)
```

- Two new paths (tag `Grafana`, operationIds `getGrafanaDeviceGpuUtilization` / `getGrafanaDeviceGpuVram`).
- Each reuses the existing `GetGrafanaDashboardLinkResponse` schema (`data: { link, enabled }`) — no new schema.

Example `200` response:

```json
{
  "code": 200,
  "data": {
    "link": "http://example-data-center/grafana/d/i-device/device?orgId=1&var-GPU_HOST=example-node-0&from=now-3h&to=now&viewPanel=50",
    "enabled": true
  },
  "msg": "fetch device gpu utilization link successfully",
  "status": "ok"
}
```

<br/>

### Test results (optional)

- `yq -o=json -I=4 docs.yaml` converts cleanly (validated in the cube-cos-api build container); `task generateApiDocs` regenerates `docs.json` with both endpoints present.
- Endpoints smoke-verified against the live API on test node `sky150` (companion cube-cos-api#596).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
