### PR TITLE
refactor: refine gpu cards response

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -5827,7 +5827,7 @@ paths:
                               remaining: 1
                               aliasName: Training_Medium
                               countLimit: 1
-                        profileCountLimit: null
+                        sriovVgpuProfileCountLimit: null
                         attachedInstances:
                           - id: vm-99
                             name: AI-Worker-01
@@ -5873,7 +5873,7 @@ paths:
                               aliasName: DC-2B
                               countLimit: null
                           migBackedVgpu: null
-                        profileCountLimit: null
+                        sriovVgpuProfileCountLimit: null
                         attachedInstances:
                           - id: vm-102
                             name: Deep-Learning-Main
@@ -5899,7 +5899,7 @@ paths:
                         profiles:
                           sriovVgpu: null
                           migBackedVgpu: null
-                        profileCountLimit: null
+                        sriovVgpuProfileCountLimit: null
                         attachedInstances: null
                         status:
                           current: unassigned
@@ -15526,7 +15526,7 @@ components:
               - gpu
               - allocationSummary
               - profiles
-              - profileCountLimit
+              - sriovVgpuProfileCountLimit
               - attachedInstances
               - status
             properties:
@@ -15573,7 +15573,7 @@ components:
                     type: integer
                   total:
                     type: integer
-              profileCountLimit:
+              sriovVgpuProfileCountLimit:
                 type: integer
                 nullable: true
               profiles:


### PR DESCRIPTION
### What type of PR is this?

refactor

### Which issue(s) this PR fixes?

N/A

### What this PR does?

refactor: refine gpu cards response

The `profileCountLimit` is only applied on sriov type gpu. 
So I renamed it from `profileCountLimit` => `sriovVgpuProfileCountLimit`.

UI Changes: https://github.com/bigstack-oss/cube-cos-ui/pull/832
SDK Changes: https://github.com/bigstack-oss/cubecos/pull/1038
API Changes: https://github.com/bigstack-oss/cube-cos-api/pull/598

### Test results (optional)

Tested on dev environment

<img width="1232" height="855" alt="image" src="https://github.com/user-attachments/assets/1077649b-5916-458f-bdee-09e7d065ccc1" />
