### PR TITLE
docs(gpu): report per-card history links on the GPU card listing (#824, #825)

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -5842,6 +5842,9 @@ paths:
                               totalMiB: 5000
                             links:
                               grafana: https://example.grafana/vm-99
+                        links:
+                          workloadHistory: https://example/grafana/d/i-device/device?orgId=1&var-GPU_HOST=cn13&var-GPU_PCIID=00000001%3A04%3A00.0&from=now-3h&to=now&viewPanel=50
+                          vramHistory: https://example/grafana/d/i-device/device?orgId=1&var-GPU_HOST=cn13&var-GPU_PCIID=00000001%3A04%3A00.0&from=now-3h&to=now&viewPanel=51
                         status:
                           current: inUse
                           isProcessing: false
@@ -5890,6 +5893,9 @@ paths:
                               totalMiB: null
                             links:
                               grafana: https://example.grafana/vm-99
+                        links:
+                          workloadHistory: https://example/grafana/d/i-device/device?orgId=1&var-GPU_HOST=cn13&var-GPU_PCIID=00000001%3A04%3A00.0&from=now-3h&to=now&viewPanel=50
+                          vramHistory: https://example/grafana/d/i-device/device?orgId=1&var-GPU_HOST=cn13&var-GPU_PCIID=00000001%3A04%3A00.0&from=now-3h&to=now&viewPanel=51
                         status:
                           current: inUse
                           isProcessing: false
@@ -15709,6 +15715,7 @@ components:
               - profiles
               - sriovVgpuProfileCountLimit
               - attachedInstances
+              - links
               - status
               - degraded
             properties:
@@ -15833,6 +15840,23 @@ components:
                       properties:
                         grafana:
                           type: string
+              links:
+                type: object
+                description: >-
+                  History charts for this one card. They are reported inline with
+                  the card because the UI offers them from its row: a link built
+                  per node would be identical on every row of the same node. Both
+                  are always present -- a card with no series (a passed-through
+                  GPU, or utilization on a MIG-enabled card) still has a chart,
+                  it is simply empty.
+                required:
+                  - workloadHistory
+                  - vramHistory
+                properties:
+                  workloadHistory:
+                    type: string
+                  vramHistory:
+                    type: string
               status:
                 type: object
                 required:

--- a/docs.yaml
+++ b/docs.yaml
@@ -5789,12 +5789,14 @@ paths:
                         pciAddress: 0000:01:00.0
                         resourceType: migBackedVgpu
                         supportResourceTypes: ["pgpu", "sriovVgpu", "migBackedVgpu"]
+                        # MIG is enabled on this card, so the framebuffer is
+                        # reported but utilization does not exist.
                         vram:
                           allocatedMiB: 80000
                           totalMiB: 100000
-                          utilizationPercent: 40
+                          utilizationPercent: null
                         gpu:
-                          utilizationPercent: 24
+                          utilizationPercent: null
                         allocationSummary:
                           current: 2
                           total: 6
@@ -5834,7 +5836,7 @@ paths:
                           - id: vm-99
                             name: AI-Worker-01
                             profileAlias: A100-1-5C
-                            utilizationPercent: 20.35
+                            utilizationPercent: null
                             memoryUsage:
                               allocatedMiB: 4200
                               totalMiB: 5000
@@ -5849,12 +5851,14 @@ paths:
                         pciAddress: 0000:01:00.1
                         resourceType: pgpu
                         supportResourceTypes: ["pgpu", "sriovVgpu"]
+                        # The card is bound to vfio-pci for passthrough, so the
+                        # host cannot see it and has no numbers for it at all.
                         vram:
-                          allocatedMiB: 81920
-                          totalMb: 81920
-                          utilizationPercent: 85
+                          allocatedMiB: null
+                          totalMiB: null
+                          utilizationPercent: null
                         gpu:
-                          utilizationPercent: 92
+                          utilizationPercent: null
                         allocationSummary:
                           current: 1
                           total: 1
@@ -5880,10 +5884,10 @@ paths:
                           - id: vm-102
                             name: Deep-Learning-Main
                             profileAlias: null
-                            utilizationPercent: 91.5
+                            utilizationPercent: null
                             memoryUsage:
-                              allocatedMiB: 78000
-                              totalMiB: 81920
+                              allocatedMiB: null
+                              totalMiB: null
                             links:
                               grafana: https://example.grafana/vm-99
                         status:
@@ -15722,6 +15726,14 @@ components:
                   $ref: "#/components/schemas/GPUSupportResourceType"
               vram:
                 type: object
+                description: >-
+                  A null field means the number does not exist for this card
+                  rather than being zero, and the card is not degraded by it. A
+                  GPU passed through to a VM (pgpu) is bound to vfio-pci and is
+                  invisible to the host, so it has no runtime stats at all; a
+                  card with MIG enabled reports its framebuffer but no
+                  utilization, because NVIDIA provides none once the card is
+                  partitioned.
                 required:
                   - allocatedMiB
                   - totalMiB
@@ -15729,10 +15741,13 @@ components:
                 properties:
                   allocatedMiB:
                     type: integer
+                    nullable: true
                   totalMiB:
                     type: integer
+                    nullable: true
                   utilizationPercent:
                     type: integer
+                    nullable: true
               gpu:
                 type: object
                 required:
@@ -15740,6 +15755,7 @@ components:
                 properties:
                   utilizationPercent:
                     type: integer
+                    nullable: true
               allocationSummary:
                 type: object
                 nullable: true
@@ -15792,6 +15808,12 @@ components:
                       nullable: true
                     utilizationPercent:
                       type: integer
+                      nullable: true
+                      description: >-
+                        Null when the value does not exist for this instance's
+                        GPU resource type: a MIG-backed vGPU reports no
+                        utilization, and a passed-through GPU is invisible to the
+                        host altogether.
                     memoryUsage:
                       type: object
                       required:
@@ -15800,8 +15822,10 @@ components:
                       properties:
                         allocatedMiB:
                           type: integer
+                          nullable: true
                         totalMiB:
                           type: integer
+                          nullable: true
                     links:
                       type: object
                       required:


### PR DESCRIPTION
### What type of PR is this?

/kind documentation

<br/>

### Which issue(s) this PR fixes?

Documents the listing change for bigstack-oss/cubecos#824 and #825.

<br/>

### What this PR does?

Each GPU card in the listing now carries its own `links.workloadHistory` and
`links.vramHistory`. They are inline with the card rather than behind their own
endpoint because the UI offers them from the card's row, and both values are pure
string building from data the listing already has — so a per-row action costs no
extra request. Same shape as the attached instances carrying their Grafana link
inline.

Both are always present. A card with no series — a passed-through GPU, or
utilization on a MIG-enabled card — still gets a link; the chart is simply empty,
which is the honest answer for that card and matches the null stats the same card
reports.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

`yq -o=json -I=4 docs.yaml` converts cleanly (1,402,086 bytes) and the binary
built from it in the x86 jail container compiles with the embedded spec.

2). make sure the api works properly

See bigstack-oss/cube-cos-api#636.

> Merge order: this PR merges **first**, then the submodule pointer in
> cube-cos-api#636 is re-bumped to the merged sha.
>
> **Stacked on #107.** This branch is rebased on top of it, so it carries #107's
> commit as well and the two cannot conflict. Cherry-picking either way was clean;
> stacking simply keeps the merge order unambiguous.
>
> **Merge order: #107 first**, then this one is a single-commit fast-forward. The
> change to review here is just the `links` block (+24 lines).
