### PR TITLE
docs(gpu): allow a null Grafana link on a GPU-attached instance (#823)

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -5892,7 +5892,7 @@ paths:
                               allocatedMiB: null
                               totalMiB: null
                             links:
-                              grafana: https://example.grafana/vm-99
+                              grafana: null
                         links:
                           workloadHistory: https://example/grafana/d/i-device/device?orgId=1&var-GPU_HOST=cn13&var-GPU_PCIID=00000001%3A04%3A00.0&from=now-3h&to=now&viewPanel=50
                           vramHistory: https://example/grafana/d/i-device/device?orgId=1&var-GPU_HOST=cn13&var-GPU_PCIID=00000001%3A04%3A00.0&from=now-3h&to=now&viewPanel=51
@@ -15840,6 +15840,16 @@ components:
                       properties:
                         grafana:
                           type: string
+                          nullable: true
+                          description: >-
+                            Null when the dashboard variables cannot be pinned:
+                            without the owning project the dashboard's tenant,
+                            hostname and instance variables all resolve on load
+                            and the page can label this VM's chart with another
+                            VM. A GPU passed through to a VM has no vGPU series
+                            to chart in the first place, so no link is the honest
+                            answer -- the same rule as the stats above, where a
+                            value that cannot be measured is null rather than 0.
               links:
                 type: object
                 description: >-


### PR DESCRIPTION
### What type of PR is this?

/kind documentation

<br/>

### Which issue(s) this PR fixes?

Follow-up to the review on bigstack-oss/cube-cos-api#635 (bigstack-oss/cubecos#823).

<br/>

### What this PR does?

Types an attached instance's `links.grafana` as nullable. It is null when the
dashboard variables cannot be pinned — in practice a GPU passed through to a VM,
whose owning project the GPU listing cannot resolve, and which has no vGPU series
to chart in the first place.

This is the same rule as the stats on the same object: a value that cannot be
measured is null rather than 0, and a link that cannot be built correctly is that
same kind of absence. `null` rather than `""` is what makes a consumer that forgets
the check fail to compile instead of rendering a link that lands on the wrong VM —
the generated SDK types it `string | null`, and the UI passes it straight into a
`href: string` prop.

The passed-through example (`vm-102`) now shows `grafana: null`, consistent with
the null stats already on that same card.

<br/>

### Test results (optional)

1). make sure the api docs have been updated

`yq -o=json -I=4 docs.yaml` converts cleanly; YAML parses.

2). make sure the api works properly

Implemented in bigstack-oss/cube-cos-api#635 — **merge this PR first**, then that
PR's submodule pointer is re-bumped to the merged sha.

> One PR rather than two: #107 and #108 already merged, so this carries the only
> remaining spec change from that review.
