### PR TITLE
docs(gpu): split an attached instance's link into workload and VRAM history (#823)

### DIFF
--- a/docs.yaml
+++ b/docs.yaml
@@ -5841,7 +5841,8 @@ paths:
                               allocatedMiB: 4200
                               totalMiB: 5000
                             links:
-                              grafana: https://example.grafana/vm-99
+                              workloadHistory: https://example/grafana/d/PVW6vU7Wz/instance?orgId=1&refresh=5m&var-TID=809049165d4d4266996fa24515006ccd&var-HOSTNAME=AI-Worker-01&var-UUID=vm-99&from=now-3h&to=now&viewPanel=36
+                              vramHistory: https://example/grafana/d/PVW6vU7Wz/instance?orgId=1&refresh=5m&var-TID=809049165d4d4266996fa24515006ccd&var-HOSTNAME=AI-Worker-01&var-UUID=vm-99&from=now-3h&to=now&viewPanel=37
                         links:
                           workloadHistory: https://example/grafana/d/i-device/device?orgId=1&var-GPU_HOST=cn13&var-GPU_PCIID=00000001%3A04%3A00.0&from=now-3h&to=now&viewPanel=50
                           vramHistory: https://example/grafana/d/i-device/device?orgId=1&var-GPU_HOST=cn13&var-GPU_PCIID=00000001%3A04%3A00.0&from=now-3h&to=now&viewPanel=51
@@ -5892,7 +5893,8 @@ paths:
                               allocatedMiB: null
                               totalMiB: null
                             links:
-                              grafana: null
+                              workloadHistory: null
+                              vramHistory: null
                         links:
                           workloadHistory: https://example/grafana/d/i-device/device?orgId=1&var-GPU_HOST=cn13&var-GPU_PCIID=00000001%3A04%3A00.0&from=now-3h&to=now&viewPanel=50
                           vramHistory: https://example/grafana/d/i-device/device?orgId=1&var-GPU_HOST=cn13&var-GPU_PCIID=00000001%3A04%3A00.0&from=now-3h&to=now&viewPanel=51
@@ -15835,21 +15837,33 @@ components:
                           nullable: true
                     links:
                       type: object
+                      description: >-
+                        History charts for this one VM's GPU resource, the
+                        VM-level counterpart of the card's links: workload and
+                        VRAM each open their own panel of the instance
+                        dashboard's vGPU row, which ships collapsed. Both are
+                        null together when the dashboard variables cannot be
+                        pinned: without the owning project the dashboard's
+                        tenant, hostname and instance variables all resolve on
+                        load and the page can label this VM's chart with another
+                        VM. A GPU passed through to a VM has no vGPU series to
+                        chart in the first place, so no link is the honest answer
+                        -- the same rule as the stats above, where a value that
+                        cannot be measured is null rather than 0. An empty chart
+                        is not such a case: a MIG-backed vGPU reports no
+                        utilization, so its workload link opens an empty panel,
+                        exactly as the card-level workloadHistory does on a
+                        MIG-enabled card.
                       required:
-                        - grafana
+                        - workloadHistory
+                        - vramHistory
                       properties:
-                        grafana:
+                        workloadHistory:
                           type: string
                           nullable: true
-                          description: >-
-                            Null when the dashboard variables cannot be pinned:
-                            without the owning project the dashboard's tenant,
-                            hostname and instance variables all resolve on load
-                            and the page can label this VM's chart with another
-                            VM. A GPU passed through to a VM has no vGPU series
-                            to chart in the first place, so no link is the honest
-                            answer -- the same rule as the stats above, where a
-                            value that cannot be measured is null rather than 0.
+                        vramHistory:
+                          type: string
+                          nullable: true
               links:
                 type: object
                 description: >-


### PR DESCRIPTION
Closes part of bigstack-oss/cubecos#823. Pairs with cube-cos-api PR (linked below); **merge this one first** — the api PR pins the submodule to it.

## What changes

`attachedInstances[].links` on `GET /nodes/{nodeName}/gpuCards`:

```diff
 links:
-  grafana: <instance dashboard, viewPanel=37>
+  workloadHistory: <instance dashboard, viewPanel=36>
+  vramHistory:     <instance dashboard, viewPanel=37>
```

The single link was hardwired to the Memory Usage panel, so a VM's **workload** history was reachable only by opening the collapsed vGPU row by hand. The new pair mirrors the card-level `workloadHistory` / `vramHistory` that each GPU card already reports, so both tables use the same key names.

Both stay nullable, together, for the reason the single link already was: without the owning project the dashboard's `TID → TENANT → HOSTNAME → UUID` variables all resolve on load and the page can label this VM's chart with another VM's name.

## ⚠️ Breaking: this renames a field

A consumer of `links.grafana` on an attached instance fails to compile against the regenerated SDK. In `cube-cos-ui` that is `NodeGpuResources/GpuDetails.tsx` (the Attached Instance table's Action column, which today reads `links.grafana`). Failing to compile is the intended outcome — the alternative is silently reading `undefined`.

## The one decision worth a second opinion

**A MIG-backed vGPU has no utilization series at all**, so its `workloadHistory` opens an empty panel. Measured on cn13 today:

```
influx -database telegraf -execute 'SELECT last(util_gpu) AS util, last(mem_used) AS mem FROM "gpu.vm" WHERE time > now()-30m GROUP BY vm_uuid, "name"'

k8s-gpu-mig    (DC-1-12Q, MIG-backed)  util: <field absent>   mem: 784
test-mig-vgpu  (DC-1-2Q,  MIG-backed)  util: <field absent>   mem: 144
k8s-gpu-sriov  (DC-12Q,   SR-IOV)      util: 0                mem: 512
```

`util_gpu` is not 0 for a MIG-backed instance, it is **absent** — consistent with `nvidia-smi vgpu -q` reporting `Utilization → N/A` for a MIG-backed vGPU while `FB Memory Usage` is fine.

I chose to **still report the link** and let the panel be empty, because that is exactly the stance the merged card-level contract already takes ("a card with no series … still gets a link; the chart is simply empty"). The alternative — null `workloadHistory` for MIG-backed rows, so the UI can disable the button — is a defensible contract too, and it is a one-line change here plus one in the api PR. @raven-pan if you prefer that, say so and I'll switch both before merge.

## Verification

- `yq -o=json -I=4 docs.yaml` converts (run in the x86 jail container, which is what the api build embeds).
- The api build embedding this spec compiles, and the api-side unit tests assert `viewPanel=36` / `37` and all three pinned variables.
